### PR TITLE
Fixed DEVNAME for Backups

### DIFF
--- a/identify.sh
+++ b/identify.sh
@@ -31,11 +31,28 @@ else
 	fi
 fi
 
+
+
+
 # Set full logfile path
 LOG=$LOGPATH$LOGFILE
 
 # Create log dir if needed
 mkdir -p "$LOGPATH"
+
+
+#check if the disk was accidentally re-inserted
+touch '$LOGPATH${$DEVNAME -3}".log"'
+LASTRIP=tail -1 '$LOGPATH${$DEVNAME -3}".log"'
+if ["$LASTRIP" == "${ID_FS_LABEL}"]; then
+	echo "Last disk reinserted. Aborting rip" >> "$LOG"
+	eject "$DEVNAME"
+	echo /opt/arm/notify.sh "\"Disk: ${ID_FS_LABEL} was previously ripped on ${DEVNAME}\" \"$LOG\"" |at -M now
+else
+	echo "${ID_FS_LABEL}" >> $LOGPATH${DEVNAME -3}".log"
+fi
+	
+
 
 #shellcheck disable=SC2094
 {

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -25,9 +25,8 @@ LOG=$4
 	#echo /opt/arm/video_transcode.sh \"$DEST\" \"$VIDEO_TITLE\" $TIMESTAMP >> $LOG
 	if [ "$RIPMETHOD" = "backup" ] && [ "$ID_CDROM_MEDIA_BD" = "1" ]; then
 		echo "Using backup method of ripping." >> "$LOG"
-		DISC="${DEVNAME: -1}"
 		# shellcheck disable=SC2086
-		makemkvcon backup --decrypt $MKV_ARGS -r disc:"$DISC" "$DEST"/
+		makemkvcon backup --decrypt $MKV_ARGS -r disc:"${DEVNAME}" "$DEST"/
 		eject "$DEVNAME"
 	elif [ "$MAINFEATURE" = true ] && [ "$ID_CDROM_MEDIA_DVD" = "1" ] && [ -z "$ID_CDROM_MEDIA_BD" ]; then
 		echo "Media is DVD and Main Feature parameter in config file is true.  Bypassing MakeMKV." >> "$LOG"


### PR DESCRIPTION
fixed error that caused disks to immediately fail eject when trying to backup.
When running the script with multiple drives, the program was failing to open the disk. the error was found to be the area of the code that you were pulling the last character of the devname to make a disk number. This was unnecessary as MakeMKV will accept DEVNAME as a disk.