### PR TITLE
Update readme for additional requirements for installation for Fresh …

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Setup 'arm' user:
     sudo apt install abcde flac imagemagick glyrc cdparanoia
     sudo apt install at
     sudo apt install python3 python3-pip
+    sudo apt-get install libcurl4-openssl-dev libssl-dev
     sudo apt-get install libdvd-pkg
     sudo dpkg-reconfigure libdvd-pkg
     sudo apt install default-jre
@@ -65,6 +66,7 @@ Setup 'arm' user:
     cd arm
     # TODO: Remove below line before merging to master
     git checkout v2_master
+    pip3 install --upgrade pip
     pip3 install -r requirements.txt
     ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
     ln -s /opt/arm/setup/.abcde.conf ~/

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Setup 'arm' user:
     ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
     ln -s /opt/arm/setup/.abcde.conf ~/
     cp /opt/arm/setup/arm@.service /etc/systemd/system/
-    cp /docs/arm.conf.sample arm.conf
+    cp docs/arm.conf.sample arm.conf
     mkdir /etc/arm/
     ln -s /opt/arm/arm.conf /etc/arm/
 


### PR DESCRIPTION
Just built v2 fresh from a new 16.04 VM.

I was getting errors with the following line:
`pip3 install -r requirements.txt`

adding `sudo apt-get install libcurl4-openssl-dev libssl-dev`
and updating pip3
`pip3 install --upgrade pip`

resolved those errors.

FYI, I am putting together an install script to automate all of these install steps, with appropriate prompts along the way. Will put that in a separate PR once I test it out on several builds.
