### PR TITLE
removed the extra quotes that caused yaml error

### DIFF
--- a/docs/arm.conf.sample
+++ b/docs/arm.conf.sample
@@ -90,7 +90,7 @@ RIPMETHOD="backup"
 MKV_ARGS=""
 
 # Remove the files created by MakeMKV after processing is complete
-DELRAWFILES="true"
+DELRAWFILES=true
 
 ##########################
 ## HandBrake Parameters ##


### PR DESCRIPTION
DELRAWFILES had quotes around the true setting, which cause the /tmp/arm_config.yaml to insert double sets of quotes which produced a parsing error. Removing these quotes resolves the error.

> yaml.parser.ParserError: while parsing a block mapping
  in "/tmp/arm_config.yaml", line 1, column 1
expected <block end>, but found '<scalar>'
  in "/tmp/arm_config.yaml", line 21, column 16

> DELRAWFILES: ""true""