### PR TITLE
Fix incorrectly named variables

### DIFF
--- a/docs/arm.conf.sample
+++ b/docs/arm.conf.sample
@@ -39,7 +39,7 @@ MEDIA_DIR="/mnt/media/ARM/Media/Movies/"
 EXTRAS_SUB="extras"
 
 # Path to installation of ARM 
-ARMINSTALLPATH="/opt/arm/"
+INSTALLPATH="/opt/arm/"
 
 # Path to directory to hold log files
 # Make sure to include trailing /
@@ -119,7 +119,7 @@ HANDBRAKE_CLI=HandBrakeCLI
 MAINFEATURE=false
 
 # Additional HandBrake arguments for DVDs.  
-HB_ARGS="--subtitle scan -F"
+HB_ARGS_DVD="--subtitle scan -F"
 
 # Additional Handbrake arguments for Bluray Discs.
 HB_ARGS_BD="--subtitle scan -F --subtitle-burned --audio-lang-list eng --all-audio"


### PR DESCRIPTION
Fixes variables to match main.py
Closes #137 

Can either be fixed in the config or in main.py, but it looked like you might have intentionally changed the HB_ARGS to HB_ARGS_DVD in main.py to the more descriptive name, so figured the config is the better place to change it.