### PR TITLE
Fix #104 by exporting disc info variables

### DIFF
--- a/video_rip.sh
+++ b/video_rip.sh
@@ -4,8 +4,8 @@
 # shellcheck source=config
 # shellcheck disable=SC1091
 source "$ARM_CONFIG"
-# shellcheck disable=SC1090
-while read info_var; do export $info_var; done < "${DISC_INFO}"
+# shellcheck disable=SC2163
+while read -r info_var; do export $info_var; done < "${DISC_INFO}"
 
 VIDEO_TITLE=$1
 HAS_NICE_TITLE=$2

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -5,7 +5,7 @@
 # shellcheck disable=SC1091
 source "$ARM_CONFIG"
 # shellcheck disable=SC2163
-while read -r info_var; do export $info_var; done < "${DISC_INFO}"
+while read -r info_var; do export "${info_var}"; done < "${DISC_INFO}"
 
 VIDEO_TITLE=$1
 HAS_NICE_TITLE=$2

--- a/video_rip.sh
+++ b/video_rip.sh
@@ -5,7 +5,7 @@
 # shellcheck disable=SC1091
 source "$ARM_CONFIG"
 # shellcheck disable=SC1090
-source "$DISC_INFO"
+while read info_var; do export $info_var; done < "${DISC_INFO}"
 
 VIDEO_TITLE=$1
 HAS_NICE_TITLE=$2


### PR DESCRIPTION
This fixes #104 because it exports the necessary variables so that they carry over to video_transcode.sh.