### PR TITLE
202 dup event protection

### DIFF
--- a/arm_wrapper.sh
+++ b/arm_wrapper.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 DEVNAME=$1
 udevadm info --query=env "/dev/$DEVNAME" > /tmp/arm_disc_info_"$DEVNAME"
-echo bash /opt/arm/identify.sh /opt/arm/config /tmp/arm_disc_info_"$DEVNAME" | at -M now
+echo bash /opt/arm/identify.sh /opt/arm/config /tmp/arm_disc_info_"$DEVNAME" "$DEVNAME" | at -M now

--- a/identify.sh
+++ b/identify.sh
@@ -2,6 +2,33 @@
 
 export ARM_CONFIG=$1
 export DISC_INFO=$2
+DEVNAME=$3
+
+mkdir -p /tmp/arm_locks
+LOCKDIR=/tmp/arm_locks/$DEVNAME
+
+function cleanup {
+    if rmdir $LOCKDIR; then
+        echo "Finished"
+    else
+        echo "Failed to remove lock directory '$LOCKDIR'"
+        exit 1
+    fi
+}
+
+# mkdir is atomic - only one instance of this script can successfully make the
+# directory.n
+if mkdir $LOCKDIR
+then
+    # this ensures that the lockdir is removed whenever this script exits.
+    # normally, sigterm, etc. if it exits via SIGKILL, the lockdir will *not* be
+    # cleaned up.
+    trap "cleanup" EXIT
+    echo "Got lock for $DEVNAME"
+else
+    echo "Exiting early from $DEVNAME because lockdir is already held"
+    exit 1
+fi
 
 echo "$ARM_CONFIG"
 


### PR DESCRIPTION
for posterity at least, here is what I ended up doing for #202 

It seems to work, but I ran into a number of other issues running Ubuntu inside virtualbox with multiple optical drives on Windows 10. Windows kept freezing and I had to reboot the machine. Ultimately I scrapped it, installed Ubuntu 16.04 directly on the host, and installed the v2_master branch of ARM which seems to be working.

I'm not sure I'd even recommend merging this as it is possible for it to get into a bad state where the lock directory is not deleted (though it tries to have a helpful message in this case). Some more complex logic that waited a while if the lock couldn't be acquired and then checked to see if an instance of makemkv was already running for the drive in question could make this nicer, but it was more complexity than I wanted to deal with.