### PR TITLE
Improve logic when skip_transcode == true

### DIFF
--- a/arm/main.py
+++ b/arm/main.py
@@ -281,7 +281,6 @@ if __name__ == "__main__":
         version = version_file.read().strip()
     logging.info("ARM version: " + version)
     logging.info(("Python version: " + sys.version).replace('\n', ""))
-    # logging.info("Python version: " + sys.version)
 
     logger.cleanuplogs(cfg['LOGPATH'], cfg['LOGLIFE'])
 

--- a/arm/main.py
+++ b/arm/main.py
@@ -156,7 +156,7 @@ def main(logfile, disc):
                     # largest_file should be largest file
                     logging.debug("Largest file is: " + largest_file_name)
                     temp_path = os.path.join(hbinpath, largest_file_name)
-                    if(os.stat(temp_path).st_size > 0): # sanity check for filesize
+                    if(os.stat(temp_path).st_size > 0):  # sanity check for filesize
                         for f in files:
                             # move main into media_dir
                             # move others into extras folder
@@ -196,7 +196,7 @@ def main(logfile, disc):
                     perm_result = utils.set_permissions(final_directory)
                     logging.info("Permissions set successfully: " + str(perm_result))
                 utils.notify("ARM notification", str(disc.videotitle) + " processing complete.")
-                logging.info("ARM processing complete")      
+                logging.info("ARM processing complete")
                 # exit
                 sys.exit()
 

--- a/arm/main.py
+++ b/arm/main.py
@@ -132,13 +132,72 @@ def main(logfile, disc):
 
             if cfg['SKIP_TRANSCODE'] and cfg['RIPMETHOD'] == "mkv":
                 logging.info("SKIP_TRANSCODE is true.  Moving raw mkv files.")
+                logging.info("NOTE: Identified main feature may not be actual main feature")
                 files = os.listdir(mkvoutpath)
-                for f in files:
-                    mkvoutfile = os.path.join(mkvoutpath, f)
-                    logging.debug("Moving file: " + mkvoutfile + " to: " + mkvoutpath + f)
-                    shutil.move(mkvoutfile, hboutpath)
+                final_directory = hboutpath
+                if disc.videotype == "movie":
+                    logging.debug("Videotype: " + disc.videotype)
+                    # if videotype is movie, then move biggest title to media_dir
+                    # move the rest of the files to the extras folder
+
+                    # find largest filesize
+                    logging.debug("Finding largest file")
+                    largest_file_name = ""
+                    for f in files:
+                        # initialize largest_file_name
+                        if largest_file_name == "":
+                            largest_file_name = f
+                        temp_path_f = os.path.join(hbinpath, f)
+                        temp_path_largest = os.path.join(hbinpath, largest_file_name)
+                        # os.path.join(cfg['MEDIA_DIR'] + videotitle)
+                        # if cur file size > largest_file size
+                        if(os.stat(temp_path_f).st_size > os.stat(temp_path_largest).st_size):
+                            largest_file_name = f
+                    # largest_file should be largest file
+                    logging.debug("Largest file is: " + largest_file_name)
+                    temp_path = os.path.join(hbinpath, largest_file_name)
+                    if(os.stat(temp_path).st_size > 0): # sanity check for filesize
+                        for f in files:
+                            # move main into media_dir
+                            # move others into extras folder
+                            if(f == largest_file_name):
+                                # largest movie
+                                utils.move_files(hbinpath, f, disc.hasnicetitle, disc.videotitle + " (" + disc.videoyear + ")", True)
+                            else:
+                                # other extras
+                                if not str(cfg['EXTRAS_SUB']).lower() == "none":
+                                    utils.move_files(hbinpath, f, disc.hasnicetitle, disc.videotitle + " (" + disc.videoyear + ")", False)
+                                else:
+                                    logging.info("Not moving extra: " + f)
+                    # Change final path (used to set permissions)
+                    final_directory = os.path.join(cfg['MEDIA_DIR'], disc.videotitle + " (" + disc.videoyear + ")")
+                    # Clean up
+                    logging.debug("Attempting to remove extra folder in ARMPATH: " + hboutpath)
+                    try:
+                        shutil.rmtree(hboutpath)
+                        logging.debug("Removed sucessfully: " + hboutpath)
+                    except Exception:
+                        logging.debug("Failed to remove: " + hboutpath)
+                else:
+                    # if videotype is not movie, then move everything
+                    # into 'Unidentified' folder
+                    logging.debug("Videotype: " + disc.videotype)
+
+                    for f in files:
+                        mkvoutfile = os.path.join(mkvoutpath, f)
+                        logging.debug("Moving file: " + mkvoutfile + " to: " + mkvoutpath + f)
+                        shutil.move(mkvoutfile, hboutpath)
+                # remove raw files, if specified in config
+                if cfg['DELRAWFILES']:
+                    logging.info("Removing raw files")
+                    shutil.rmtree(mkvoutpath)
+                # set file to default permissions '777'
+                if cfg['SET_MEDIA_PERMISSIONS']:
+                    perm_result = utils.set_permissions(final_directory)
+                    logging.info("Permissions set successfully: " + str(perm_result))
                 utils.notify("ARM notification", str(disc.videotitle) + " processing complete.")
-                logging.info("ARM processing complete")
+                logging.info("ARM processing complete")      
+                # exit
                 sys.exit()
 
         if disc.disctype == "bluray" and cfg['RIPMETHOD'] == "mkv":
@@ -216,7 +275,7 @@ if __name__ == "__main__":
         sys.exit()
 
     logging.info("Starting ARM processing at " + str(datetime.datetime.now()))
-
+    
     # Log version number
     with open(os.path.join(cfg['INSTALLPATH'], 'VERSION')) as version_file:
         version = version_file.read().strip()

--- a/arm/main.py
+++ b/arm/main.py
@@ -275,7 +275,7 @@ if __name__ == "__main__":
         sys.exit()
 
     logging.info("Starting ARM processing at " + str(datetime.datetime.now()))
-    
+
     # Log version number
     with open(os.path.join(cfg['INSTALLPATH'], 'VERSION')) as version_file:
         version = version_file.read().strip()

--- a/arm/utils.py
+++ b/arm/utils.py
@@ -243,6 +243,7 @@ def rip_data(disc, datapath, logfile):
 
     return False
 
+
 def set_permissions(directory_to_traverse):
     try:
         corrected_chmod_value = int(str(cfg['CHMOD_VALUE']), 8)

--- a/arm/utils.py
+++ b/arm/utils.py
@@ -261,3 +261,4 @@ def set_permissions(directory_to_traverse):
         err = "Permissions setting failed as: " + str(e)
         logging.error(err)
         return False
+    

--- a/arm/utils.py
+++ b/arm/utils.py
@@ -242,3 +242,22 @@ def rip_data(disc, datapath, logfile):
             # sys.exit(err)
 
     return False
+
+def set_permissions(directory_to_traverse):
+    try:
+        corrected_chmod_value = int(str(cfg['CHMOD_VALUE']), 8)
+        logging.info("Setting permissions to: " + str(cfg['CHMOD_VALUE']) + " on: " + directory_to_traverse)
+        os.chmod(directory_to_traverse, corrected_chmod_value)
+
+        for dirpath, l_directories, l_files in os.walk(directory_to_traverse):
+            for cur_dir in l_directories:
+                logging.debug("Setting path: " + cur_dir + " to permissions value: " + str(cfg['CHMOD_VALUE']))
+                os.chmod(os.path.join(dirpath, cur_dir), corrected_chmod_value)
+            for cur_file in l_files:
+                logging.debug("Setting file: " + cur_file + " to permissions value: " + str(cfg['CHMOD_VALUE']))
+                os.chmod(os.path.join(dirpath, cur_file), corrected_chmod_value)
+        return True
+    except Exception as e:
+        err = "Permissions setting failed as: " + str(e)
+        logging.error(err)
+        return False

--- a/arm/utils.py
+++ b/arm/utils.py
@@ -261,4 +261,3 @@ def set_permissions(directory_to_traverse):
         err = "Permissions setting failed as: " + str(e)
         logging.error(err)
         return False
-    

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -12,14 +12,16 @@ ARM_CHECK_UDF: true
 GET_VIDEO_TITLE: true
 
 # Skip transcoding if you want the original MakeMKV files as your final output
-# Thiw will produce the highest quality videos (and use the most storage)
+# This will produce the highest quality videos (and use the most storage)
 # Note: RIPMETHOD must be set to "mkv" for this feature to work
+# Note: The largest file will be considered to be the "main feature" but there are cases when this is not true
+# to avoid losing a desired track, use this feature with an EXTRAS_SUB value that is not "None"
 SKIP_TRANSCODE: false
 
 # Video type identification.  Options are "auto", "series", "movie".
 # If "auto" then ARM will get the video type when quering the movie webservice.  This is default.
 # If the disc is not clearly a movie or series, or if ARM is having difficulty getting the right video type
-# you can overrie the automatic identification with "series" or "movie"
+# you can override the automatic identification with "series" or "movie"
 VIDEOTYPE: "auto"
 
 # Minimum length of track for ARM rip (in seconds)
@@ -70,7 +72,7 @@ LOGLIFE: 1
 
 # Enabling this seting will allow you to adjust the default file permissions of the outputted files
 # The default value is set to 777 for read/write/execute for all users, but can be changed below using the "CHMOD_VALUE" setting
-# This setting is helpfuly when storing the data locally on the system
+# This setting is helpful when storing the data locally on the system
 SET_MEDIA_PERMISSIONS: false
 CHMOD_VALUE: 777
 SET_MEDIA_OWNER: false


### PR DESCRIPTION
Fixes #220, and partially implements #223.

Tested with Ubuntu Server 18.04 with movies "Beauty and the Beast (Live Action) (2017)" and "Thor Ragnarok (2017)". Both are Blu-ray Discs. Beauty and the Beast has 4 tracks over 600 seconds and serves as a test of moving a movie with multiple titles that is correctly identified. Thor has 2 tracks over 600 seconds and is not correctly identified as a movie. It serves as a test of a misidentified movie with multiple tracks.

When skip_transcode==true, and extras_sub==None, then extras will not be moved. This functionality only exists when skip_transcode is on.

Logic added for when skip_transcode == true

- move_files is now utilized meaning files are properly moved and named when it is correctly identified as a "movie". When not identified as a "movie" the old method is used as a fallback. Main features are identified by size. Largest is assumed to be main feature
- raw_folders are now removed if specified in config
- extra empty folder in the arm path is removed when type is "movie"
- permissions are now properly set. set_permissions utility added that recursively changes the permissions of all files and directories below it. Returns true is successful, and false is un-successful. 

sample.yaml is updated to reflect the possibility of a main feature being misidentified and deleted if extras_sub is "None". This is the only mention of "None" feature in Extras_sub as it is only activated when skip_transcode == true. Some spelling fixes.