### PR TITLE
Windows Media occassionally returns no year

### DIFF
--- a/arm/getmovietitle.py
+++ b/arm/getmovietitle.py
@@ -46,7 +46,10 @@ def getdvdtitle(disc):
         dvd_title = doc['METADATA']['MDR-DVD']['dvdTitle']
         dvd_release_date = doc['METADATA']['MDR-DVD']['releaseDate']
         dvd_title = dvd_title.strip()
-        dvd_release_date = dvd_release_date.split()[0]
+        if dvd_release_date is not None:
+            dvd_release_date = dvd_release_date.split()[0]
+        else:
+            dvd_release_date = ""
     except KeyError:
         logging.error("Windows Media request returned no result.  Likely the DVD is not in their database.")
         return[None, None]


### PR DESCRIPTION
These changes handle a no year return.  Otherwise, an exception is raised and then ARM thinks this is a Bluray.