### PR TITLE
framework and logging reorganization

### DIFF
--- a/arm/classes.py
+++ b/arm/classes.py
@@ -65,9 +65,11 @@ class Disc(object):
         return s
 
     def eject(self):
-        """Eject disc if it hasn't previously been ejected"""
-
-        # print("Value is " + str(self.ejected))
-        if not self.ejected:
-            os.system("eject " + self.devpath)
-            self.ejected = True
+        if cfg['EJECT']:
+            logging.debug("Eject disc")
+            # print("Value is " + str(self.ejected))
+            if not self.ejected:
+                os.system("eject " + self.devpath)
+                self.ejected = True
+        else:
+            logging.debug("Do not eject disc")

--- a/arm/main.py
+++ b/arm/main.py
@@ -75,7 +75,8 @@ def log_arm_params(disc):
     logging.info("emby_server: " + cfg['EMBY_SERVER'])
     logging.info("emby_port: " + cfg['EMBY_PORT'])
     logging.info("notify_rip: " + str(cfg['NOTIFY_RIP']))
-    logging.info("notify_transcode " + str(cfg['NOTIFY_TRANSCODE']))
+    logging.info("notify_transcode: " + str(cfg['NOTIFY_TRANSCODE']))
+    logging.info("eject: " + str(cfg['EJECT']))
     logging.info("**** End of config parameters ****")
 
 

--- a/scripts/handbrake_isoTOmp4.sh
+++ b/scripts/handbrake_isoTOmp4.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+echo Input ISO Name Without .ISO:
+read isofolder
+isoname=$isofolder.ISO
+echo Gonig to be converting $isoname
+sleep 2
+mkdir ./$isofolder
+rawout=$(HandBrakeCLI -i ./$isoname -t 0 2>&1 >/dev/null)
+#read handbrake's stderr into variable
+
+count=$(echo $rawout | grep -Eao "\\+ title [0-9]+:" | wc -l)
+#parse the variable using grep to get the count
+
+for i in $(seq $count)
+do
+	    HandBrakeCLI --input ./$isoname --title $i --preset Normal --output ./$isof$
+done

--- a/scripts/manual.sh
+++ b/scripts/manual.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+## original usage
+#/opt/arm/scripts/arm_wrapper.sh sr0
+
+disc="/dev/sr0"
+while getopts ":hf:" opt; do
+	case $opt in
+		h)
+			echo "usage: -h: This help menu"
+			echo "       -f: /path/to/file.
+otherwise default to /dev/sr0"
+			echo "       -e: noeject"
+			exit 0
+			;;
+		f)
+			echo "-f $OPTARG"
+			disc=$OPTARG
+			;;
+		e)
+			echo "-e noeject"
+			eject=false
+			;;
+		\?)
+			echo "invalid option"
+			exit 1
+			;;
+	esac
+done
+
+/usr/bin/python3 /opt/arm/arm/main.py -d "$disc"

--- a/scripts/update_makemkv.sh
+++ b/scripts/update_makemkv.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+#newkey=T-_r0kX0iTg1cpZPCL1sofKlaPwiCGGg_PkNKUwSxCy4SlbHfDSF9CSNE5MGRTRh9BPq
+newkey=$(curl -A "Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Version/5.0.2 Mobile/8J2 Safari/6533.18.5" https://cable.ayra.ch/makemkv/api.php?raw)
+newkey="app_Key=\"$newkey\""
+settingsfile='/home/arm/.MakeMKV/settings.conf'
+#echo $newkey
+if grep -q app_Key $settingsfile; then
+	echo found correct line.
+	sed -i "s/app_Key.*/$newkey/" $settingsfile
+else
+	echo could not find line, dump at the bottom.
+	echo $newkey >> $settingsfile
+fi
+cat $settingsfile

--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -13,8 +13,6 @@
 # Enabled getalbumart
 # Change output format from artist-album to artist/album
 
-
-
 INTERACTIVE=n
 
 # Encode tracks immediately after reading. Saves disk space, gives
@@ -63,7 +61,7 @@ CDPARANOIAOPTS="--never-skip=40"
 CDDISCID=cd-discid            
                                
 # Give the base location here for the encoded music files.
-OUTPUTDIR="/mnt/media/ARM/emby/music/"               
+OUTPUTDIR="/home/arm/Music"                
 
 # The default actions that abcde will take.
 ACTIONS=cddb,playlist,getalbumart,read,encode,replaygain,tag,move,clean

--- a/setup/51-automedia.rules
+++ b/setup/51-automedia.rules
@@ -5,5 +5,3 @@
 # ACTION=="change", SUBSYSTEM=="block", RUN+="/opt/arm/arm/main.py -l '%E{ID_FS_LABEL}' -d '%E{DEVNAME}'"
 # ACTION=="change", SUBSYSTEM=="block", TAG+="systemd", KERNEL=="sr[0-9]*|vdisk*|xvd*", ENV{DEVTYPE}=="disk", RUN+="/bin/systemctl start arm@%k.service"
 ACTION=="change", SUBSYSTEM=="block", RUN+="/opt/arm/scripts/arm_wrapper.sh %k"
-
-

--- a/setup/install.sh
+++ b/setup/install.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+echo set variables
+ARMSETUP="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+ARMDIR=$ARMSETUP/..
+ARMLOG=$ARMDIR/logs
+ARMSCRIPTS=$ARMDIR/scripts
+ARMCONF=$ARMDIR/conf/arm.yaml
+ARMSOURCE=$ARMDIR/arm
+
+echo create symlinks
+ln -s /opt/arm $ARMDIR
+ln -s /var/log/arm $ARMLOG
+ln -s /etc/arm.yaml $ARMCONF
+ln -s /home/arm/.abcde.conf $ARMSETUP/.abcde.conf
+ln -s /lib/udev/rules.d/51-automedia.rules $ARMSETUP/51-automedia.rules
+
+echo perform setup
+$ARMSCRIPTS/update_makemkv.sh
+echo pseudocode: if armconf not exist, copy armdir/docs/arm.yaml.sample armconf
+echo I dunno, probably more. Check logger.py for checking filepath
+


### PR DESCRIPTION
Pretty sure `scripts/handbrake_isoTOmp4.sh` doesn't actually work.
made EJECT optional
`scripts/manual.sh` probably doesn't work either
`scripts/update_makemkv.sh` automate license update. Change browser agent string?
`setup/.abcde.conf` I don't know why this changed. I don't rip music
`setup/install.sh` simplify setup and make it easier to reference file locations