### PR TITLE
Implement an override setting for the identified disc type

### DIFF
--- a/arm/identify.py
+++ b/arm/identify.py
@@ -1,9 +1,9 @@
 #!/usr/bin/python3
 
 import os
-import sys # noqa # pylint: disable=unused-import
+import sys  # noqa # pylint: disable=unused-import
 import logging
-import classes # noqa # pylint: disable=unused-import
+import classes  # noqa # pylint: disable=unused-import
 import getmovietitle
 import getvideotype
 import utils
@@ -72,3 +72,7 @@ def identify(disc, logfile):
             logging.debug("Identification complete: " + str(disc))
 
     os.system("umount " + disc.devpath)
+
+    if cfg["OVERRIDE_DISC_TYPE"]:
+        logging.debug("OVERRIDE_DISC_TYPE setting is set. Changing disctype to '" + cfg["OVERRIDE_DISC_TYPE"] + "'")
+        disc.disctype = cfg["OVERRIDE_DISC_TYPE"]

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -30,6 +30,9 @@ MINLENGTH: "600"
 # Maximum length of track for ARM rip (in seconds)
 MAXLENGTH: "99999"
 
+# Actual identified disc type is replaced. Options are "music", "dvd", "bluray" and "data"
+# OVERRIDE_DISC_TYPE: "data"
+
 #####################
 ## Directory setup ##
 #####################


### PR DESCRIPTION
I want to rip alot of cds with games on them from magazines. ARM identifies many of them as music dics and fails. This is why i implemented an override for the identification.