### PR TITLE
Replace cat command with dd for more control

### DIFF
--- a/arm/utils.py
+++ b/arm/utils.py
@@ -203,7 +203,7 @@ def rip_music(disc, logfile):
 
 def rip_data(disc, datapath, logfile):
     """
-    Rip data disc using cat on the command line\n
+    Rip data disc using dd on the command line\n
     disc = disc object\n
     datapath = path to copy data to\n
     logfile = location of logfile\n
@@ -221,9 +221,10 @@ def rip_data(disc, datapath, logfile):
 
         logging.info("Ripping data disc to: " + filename)
 
-        cmd = 'cat "{0}" > "{1}" 2>> {2}'.format(
+        cmd = 'dd if="{0}" of="{1}" {2} 2>> {3}'.format(
             disc.devpath,
             filename,
+            cfg["DATA_RIP_PARAMETERS"],
             logfile
         )
 

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -30,6 +30,9 @@ MINLENGTH: "600"
 # Maximum length of track for ARM rip (in seconds)
 MAXLENGTH: "99999"
 
+# Additional parameters for dd. e.g. "conv=noerror,sync" for ignoring read errors
+DATA_RIP_PARAMETERS: ""
+
 #####################
 ## Directory setup ##
 #####################


### PR DESCRIPTION
I need a bit more control over the copy process so i replaced cat with dd. This way i can add a `conv=noerror,sync` in which case the copy process is not interrupted. See [https://superuser.com/a/622553](https://superuser.com/a/622553).