### PR TITLE
Added logic for trying to parse raw DVD title using OMDB instead of windowsmedia services because it is dead.

### DIFF
--- a/arm/ripper/handbrake.py
+++ b/arm/ripper/handbrake.py
@@ -29,14 +29,19 @@ def handbrake_mainfeature(srcpath, basepath, logfile, job):
 
     filename = os.path.join(basepath, job.title + "." + job.config.DEST_EXT)
     filepathname = os.path.join(basepath, filename)
+    logging.info("Ripping title Mainfeature to " + shlex.quote(filepathname))
 
     get_track_info(srcpath, job)
 
     track = job.tracks.filter_by(main_feature=True).first()
 
-    logging.info("Ripping title Mainfeature to " + shlex.quote(filepathname))
+    if track is None:
+      msg = "No main feature found by Handbrake. Turn MAINFEATURE to false in arm.yml and try again."
+      logging.error(msg)
+      raise RuntimeError(msg)
 
     track.filename = track.orig_filename = filename
+
     db.session.commit()
 
     if job.disctype == "dvd":
@@ -219,7 +224,7 @@ def get_track_info(srcpath, job):
     srcpath = Path to disc\n
     job = Job instance\n
     """
-    
+
     logging.info("Using HandBrake to get information on all the tracks on the disc.  This will take a few minutes...")
 
     cmd = '{0} -i {1} -t 0 --scan'.format(

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -98,7 +98,7 @@ def identify_dvd(job):
 
     # TODO: split this out to another file/function and loop depending how many replacements
     #       need to be done
-    dvd_title = job.label.replace("_", " ").replace("16X9", "").replace("4X3", "").replace("_SE", "")
+    dvd_title = job.label.replace("_", " ").replace("16X9", "").replace("4X3", "").replace("_SE", "").replace("THX", "").replace("DTS", "")
     dvd_release_date = ""
 
     job.title = job.title_auto = dvd_title

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -98,7 +98,7 @@ def identify_dvd(job):
 
     # TODO: split this out to another file/function and loop depending how many replacements
     #       need to be done
-    dvd_title = job.label.replace("_", " ").replace("16X9", "")
+    dvd_title = job.label.replace("_", " ").replace("16X9", "").replace("4X3", "").replace("_SE", "")
     dvd_release_date = ""
 
     job.title = job.title_auto = dvd_title

--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -92,7 +92,8 @@ def identify_dvd(job):
     logging.debug(str(job))
 
     #  Some older DVDs aren't actually labelled
-    if not job.label:
+    #  or are labelled generically DVD_VIDEO
+    if not job.label or job.label.casefold() == "dvd_video":
       job.label = "not identified"
 
     # TODO: split this out to another file/function and loop depending how many replacements

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,4 @@ omdb>=0.10.0
 psutil>=5.4.6
 robobrowser>=0.5.3
 tinydownload>=0.1.0
-
-
+werkzeug==0.16.0


### PR DESCRIPTION
Modified omdb api logic in case there is no year to start.

Added 16X9 to title things to strip.

Handled a rare condition where a DVD does not actually have a name/label.

Stop OMDB lookups when we cannot get a proper title from the DVD Label

Added a logging error when a mainfeature is not found.