### PR TITLE
Adding additional call to OMDB without year if first call failed

### DIFF
--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -241,6 +241,9 @@ def get_video_details(job):
                 logging.debug("Trying title: " + title)
                 response = callwebservice(job, omdb_api_key, title, year)
                 logging.debug("response: " + response)
+                if response == "fail":
+                    logging.debug("Removing year...")
+                    response = callwebservice(job, omdb_api_key, title, "")
 
 
 def callwebservice(job, omdb_api_key, dvd_title, year=""):


### PR DESCRIPTION
Some BluRays have bad year information so making sure the removal of year call applies to the slicing off last word call as well.