### PR TITLE
Flake8 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,10 @@ arm.conf
 *.pyc
 .gitignore
 arm.yaml
+
+# PEP 582 
+__pypackages__
+
+# JetBrains tools
+.idea/
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
   - "3.5"
+before_install:
+  - sudo apt-get update
+  - sudo apt-get -y install libcurl4-openssl-dev libssl-dev
 install: "pip install -r requirements.txt"
 script:
   - flake8 arm

--- a/arm/getmovietitle.py
+++ b/arm/getmovietitle.py
@@ -64,13 +64,13 @@ def getbluraytitle(disc):
             doc = xmltodict.parse(xml_file.read())
     except OSError:
         logging.error("Disc is a bluray, but bdmt_eng.xml could not be found.  Disc cannot be identified.")
-        return [None, None]
+        return[None, None]
 
     try:
         bluray_title = doc['disclib']['di:discinfo']['di:title']['di:name']
     except KeyError:
         logging.error("Could not parse title from bdmt_eng.xml file.  Disc cannot be identified.")
-        return [None, None]
+        return[None, None]
 
     bluray_modified_timestamp = os.path.getmtime(disc.mountpoint + '/BDMV/META/DL/bdmt_eng.xml')
     bluray_year = (datetime.datetime.fromtimestamp(bluray_modified_timestamp).strftime('%Y'))

--- a/arm/getmovietitle.py
+++ b/arm/getmovietitle.py
@@ -7,11 +7,11 @@ import datetime
 import pydvdid
 import unicodedata
 import xmltodict
-import sys  # noqa # pylint: disable=unused-import
+import sys # noqa # pylint: disable=unused-import
 import re
 import logging
-import logger  # noqa # pylint: disable=unused-import
-import classes  # noqa # pylint: disable=unused-import
+import logger # noqa # pylint: disable=unused-import
+import classes # noqa # pylint: disable=unused-import
 
 
 def entry():
@@ -42,7 +42,7 @@ def getdvdtitle(disc):
             format(crc64)).read()
     except OSError:
         logging.error("Failed to reach windowsmedia web service")
-        return [None, None]
+        return[None, None]
 
     try:
         doc = xmltodict.parse(dvd_info_xml)
@@ -52,9 +52,9 @@ def getdvdtitle(disc):
         dvd_release_date = dvd_release_date.split()[0]
     except KeyError:
         logging.error("Windows Media request returned no result.  Likely the DVD is not in their database.")
-        return [None, None]
+        return[None, None]
 
-    return [dvd_title, dvd_release_date]
+    return[dvd_title, dvd_release_date]
 
 
 def getbluraytitle(disc):
@@ -116,10 +116,10 @@ def main(disc):
             disc_title = clean_for_filename(disc_title)
             logging.info("getmovietitle bluray title found: " + disc_title + " : " + disc_year)
             disc.hasnicetitle = True
-        return (disc_title, disc_year)
+        return(disc_title, disc_year)
     else:
         logging.info(str(disc_title) + " : " + str(disc_year))
         if disc_title:
             disc.hasnicetitle = True
         logging.info("Returning: " + str(disc_title) + ", " + str(disc_year))
-        return (disc_title, disc_year)
+        return(disc_title, disc_year)

--- a/arm/getmovietitle.py
+++ b/arm/getmovietitle.py
@@ -7,11 +7,11 @@ import datetime
 import pydvdid
 import unicodedata
 import xmltodict
-import sys # noqa # pylint: disable=unused-import
+import sys  # noqa # pylint: disable=unused-import
 import re
 import logging
-import logger # noqa # pylint: disable=unused-import
-import classes # noqa # pylint: disable=unused-import
+import logger  # noqa # pylint: disable=unused-import
+import classes  # noqa # pylint: disable=unused-import
 
 
 def entry():
@@ -42,7 +42,7 @@ def getdvdtitle(disc):
             format(crc64)).read()
     except OSError:
         logging.error("Failed to reach windowsmedia web service")
-        return[None, None]
+        return [None, None]
 
     try:
         doc = xmltodict.parse(dvd_info_xml)
@@ -52,9 +52,9 @@ def getdvdtitle(disc):
         dvd_release_date = dvd_release_date.split()[0]
     except KeyError:
         logging.error("Windows Media request returned no result.  Likely the DVD is not in their database.")
-        return[None, None]
+        return [None, None]
 
-    return[dvd_title, dvd_release_date]
+    return [dvd_title, dvd_release_date]
 
 
 def getbluraytitle(disc):
@@ -64,13 +64,13 @@ def getbluraytitle(disc):
             doc = xmltodict.parse(xml_file.read())
     except OSError:
         logging.error("Disc is a bluray, but bdmt_eng.xml could not be found.  Disc cannot be identified.")
-        return[None, None]
+        return [None, None]
 
     try:
         bluray_title = doc['disclib']['di:discinfo']['di:title']['di:name']
     except KeyError:
         logging.error("Could not parse title from bdmt_eng.xml file.  Disc cannot be identified.")
-        return[None, None]
+        return [None, None]
 
     bluray_modified_timestamp = os.path.getmtime(disc.mountpoint + '/BDMV/META/DL/bdmt_eng.xml')
     bluray_year = (datetime.datetime.fromtimestamp(bluray_modified_timestamp).strftime('%Y'))
@@ -87,12 +87,12 @@ def getbluraytitle(disc):
 
 def clean_for_filename(string):
     """ Cleans up string for use in filename """
-    string = re.sub('\[(.*?)\]', '', string)
-    string = re.sub('\s+', ' ', string)
+    string = re.sub(r'\[(.*?)\]', '', string)
+    string = re.sub(r'\s+', ' ', string)
     string = string.replace(' : ', ' - ')
     string = string.replace(': ', ' - ')
     string = string.strip()
-    return re.sub('[^\w\-_\.\(\) ]', '', string)
+    return re.sub(r'[^\w\-_\.\(\) ]', '', string)
 
 # pylint: disable=C0103
 
@@ -116,10 +116,10 @@ def main(disc):
             disc_title = clean_for_filename(disc_title)
             logging.info("getmovietitle bluray title found: " + disc_title + " : " + disc_year)
             disc.hasnicetitle = True
-        return(disc_title, disc_year)
+        return (disc_title, disc_year)
     else:
         logging.info(str(disc_title) + " : " + str(disc_year))
         if disc_title:
             disc.hasnicetitle = True
         logging.info("Returning: " + str(disc_title) + ", " + str(disc_year))
-        return(disc_title, disc_year)
+        return (disc_title, disc_year)

--- a/arm/getmovietitle.py
+++ b/arm/getmovietitle.py
@@ -40,7 +40,7 @@ def getdvdtitle(disc):
         dvd_info_xml = urllib.request.urlopen(
             "http://metaservices.windowsmedia.com/pas_dvd_B/template/GetMDRDVDByCRC.xml?CRC={0}".
             format(crc64)).read()
-    except OSError as e:
+    except OSError:
         logging.error("Failed to reach windowsmedia web service")
         return[None, None]
 
@@ -62,7 +62,7 @@ def getbluraytitle(disc):
     try:
         with open(disc.mountpoint + '/BDMV/META/DL/bdmt_eng.xml', "rb") as xml_file:
             doc = xmltodict.parse(xml_file.read())
-    except OSError as e:
+    except OSError:
         logging.error("Disc is a bluray, but bdmt_eng.xml could not be found.  Disc cannot be identified.")
         return[None, None]
 

--- a/arm/handbrake.py
+++ b/arm/handbrake.py
@@ -275,7 +275,7 @@ def get_title_length(title, srcpath):
             stderr=subprocess.STDOUT,
             shell=True
         ).decode("utf-8").splitlines()
-    except subprocess.CalledProcessError as hb_error:
+    except subprocess.CalledProcessError:
         # err = "Call to handbrake failed with code: " + str(hb_error.returncode) + "(" + str(hb_error.output) + ")"
         logging.debug("Couldn't find a valid track.  Try running the command manually to see more specific errors.")
         return(-1)

--- a/arm/handbrake.py
+++ b/arm/handbrake.py
@@ -106,9 +106,9 @@ def handbrake_all(srcpath, basepath, logfile, disc):
         # pattern = re.compile(r'\bscan\:.*\btitle\(s\)')
 
         if disc.disctype == "bluray":
-            result = re.search('scan: BD has (.*) title\(s\)', line)
+            result = re.search(r'scan: BD has (.*) title\(s\)', line)
         else:
-            result = re.search('scan: DVD has (.*) title\(s\)', line)
+            result = re.search(r'scan: DVD has (.*) title\(s\)', line)
 
         if result:
             titles = result.group(1)


### PR DESCRIPTION
Resolves #359 

In addition to fixing the Flake8 warnings, I've added two additional entries to the `.gitignore` file - I would normally have submitted these into a separate PR but it seemed a bit spurious!

While most of these changes are clearly conflict free, I should note that the change to `arm/handbrake.py#L278` removes an unused variable that is referred to in some commented out code on L279.

If you would like any changes to this PR, let me know and I will gladly adjust it.