### PR TITLE
Cleanup README and BASH scripts and automate MakeMKV install.

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ sudo dpkg-reconfigure libdvd-pkg
 
 ```bash
 cd /opt
-sudo mkdir arm
+sudo mkdir -p arm
 sudo chown arm:arm arm
 sudo chmod 775 arm
 sudo git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
@@ -143,7 +143,7 @@ sudo pip3 install -r requirements.txt
 sudo cp /opt/arm/setup/51-automedia.rules /etc/udev/rules.d/
 sudo ln -s /opt/arm/setup/.abcde.conf /home/arm/
 sudo cp docs/arm.yaml.sample arm.yaml
-sudo mkdir /etc/arm/
+sudo mkdir -p /etc/arm/
 sudo ln -s /opt/arm/arm.yaml /etc/arm/
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,61 +2,35 @@
 
 [![Build Status](https://travis-ci.org/automatic-ripping-machine/automatic-ripping-machine.svg?branch=v2_master)](https://travis-ci.org/automatic-ripping-machine/automatic-ripping-machine)
 
-## Upgrading from v2_master to v2.2_dev
-
-If you wish to upgrade from v2_master to v2.2_dev instead of a clean install, these directions should get you there.  
-
-```bash
-cd /opt/arm
-sudo git checkout v2_master
-sudo pip3 install -r requirements.txt
-```
-Backup config file and replace it with the updated config
-```bash
-mv arm.yaml arm.yaml.old
-cp docs/arm.yaml.sample arm.yaml
-```
-
-There are new config parameters so review the new arm.yaml file
-
-Make sure the 'arm' user has write permissions to the db directory (see your arm.yaml file for locaton). is writeable by the arm user.  A db will be created when you first run ARM.
-
-Make sure that your rules file is properly **copied** instead of linked:
-```
-sudo rm /usr/lib/udev/rules.d/51-automedia.rules
-sudo cp /opt/arm/setup/51-automedia.rules /etc/udev/rules.d/
-```
-Otherwise you may not get the auto-launching of ARM when a disc is inserted behavior
-on Ubuntu 20.04.
-
-Please log any issues you find.  Don't forget to run in DEBUG mode if you need to submit an issue (and log files).  Also, please note that you are running 2.2_dev in your issue.
-
-
 ## Overview
 
 Insert an optical disc (Blu-Ray, DVD, CD) and checks to see if it's audio, video (Movie or TV), or data, then rips it.
 
 See: https://b3n.org/automatic-ripping-machine
 
-
 ## Features
 
-- Detects insertion of disc using udev
-- Auto downloads keys_hashed.txt and KEYDB.cfg using robobrowser and tinydownloader
+- Detects insertion of disc using `udev`.
+- Auto downloads keys_hashed.txt and KEYDB.cfg using robobrowser and tinydownloader.
 - Determines disc type...
   - If video (Blu-Ray or DVD)
-    - Retrieve title from disc or Windows Media MetaServices API to name the folder "movie title (year)" so that Plex or Emby can pick it up
-    - Determine if video is Movie or TV using OMDb API
-    - Rip using MakeMKV or HandBrake (can rip all features or main feature)
-    - Eject disc and queue up Handbrake transcoding when done
-    - Transcoding jobs are asynchronusly batched from ripping
-    - Send notification when done via IFTTT or Pushbullet
-  - If audio (CD) - rip using abcde
-  - If data (Blu-Ray, DVD, or CD) - make an ISO backup
-- Headless, designed to be run from a server
-- Can rip from multiple-optical drives in parallel
-- HTML UI to interact with ripping jobs, view logs, etc
+    - Retrieve title from disc or Windows Media MetaServices API to name the folder "movie title (year)" so that Plex or Emby can pick it up.
+    - Determine if video is Movie or TV using OMDb API.
+    - Rip using MakeMKV or HandBrake (can rip all features or main feature).
+    - Eject disc and queue up Handbrake transcoding when done.
+    - Transcoding jobs are asynchronusly batched from ripping.
+    - Send notification when done via IFTTT or Pushbullet.
+  - If audio (CD) - rip using abcde.
+  - If data (Blu-Ray, DVD, or CD) - make an ISO backup.
+- Headless, designed to be run from a server.
+- Can rip from multiple-optical drives in parallel.
+- HTML UI to interact with ripping jobs, view logs, etc.
 
+## Usage
+
+- Insert disc.
+- Wait for disc to eject.
+- Repeat.
 
 ## Requirements
 
@@ -69,49 +43,90 @@ See: https://b3n.org/automatic-ripping-machine
 If you have a new DVD drive that you haven't used before, some require setting the region before they can play anything.  Be aware most DVD players only let you change the region a handful (4 or 5?) of times then lockout any further changes.  If your region is already set or you have a region free DVD drive you can skip this step.
 
 ```bash
-sudo apt-get install regionset
+sudo apt install -y regionset
 sudo regionset /dev/sr0
 ```
 
-## Install
+## Automatic Install Script For OpenMediaVault/Debian
+
+**This MUST be run as root!**
+
+**For the attended install use:**
+
+```
+sudo apt install -y wget
+wget https://raw.githubusercontent.com/automatic-ripping-machine/automatic-ripping-machine/v2_master/scripts/debian-setup.sh
+chmod +x debian-setup.sh
+./debian-setup.sh
+```
+
+`reboot` to complete installation.
+
+**For the silent install use**
+
+```
+apt -qqy install wget
+
+wget https://raw.githubusercontent.com/automatic-ripping-machine/automatic-ripping-machine/v2_master/scripts/deb-install-quiet.sh
+chmod +x deb-install-quiet.sh
+./deb-install-quiet.sh
+```
+
+`reboot` to complete installation.
+
+**Details about this script**
+
+The script installs all dependencies, a service for the ARMui and the fstab entry for sr0, if you have more than one drive you will need to make the mount folder and insert any additional fstab entries.
+The attended installer will do all of the necessary installs and deal with dependencies but will need user input.
+The silent install will remove the need for the user to interact with the screen after intering the arm userpassword.
+
+**The reason for the installer script ?**
+
+The debian installer script has different commands than the ubuntu follow along commands. The reason being is that some of the commands that work on ubunutu do not work.
+You can also run each line of the script in a console or ssh terminal.
+
+## Manual Install
 
 **Setup 'arm' user and ubuntu basics:**
 
 Sets up graphics drivers, does Ubuntu update & Upgrade, gets Ubuntu to auto set up driver, and finally installs and setups up avahi-daemon
+
 ```bash
-sudo apt update -y && sudo apt upgrade -y 
-***optional (was not required for me): sudo add-apt-repository ppa:graphics-drivers/ppa
-sudo apt install avahi-daemon -y && sudo systemctl restart avahi-daemon
-sudo apt install ubuntu-drivers-common -y && sudo ubuntu-drivers install 
+sudo apt update && sudo apt upgrade -y
+### optional (was not required for me): sudo add-apt-repository ppa:graphics-drivers/ppa
+sudo apt install -y avahi-daemon && sudo systemctl restart avahi-daemon
+sudo apt install -y ubuntu-drivers-common && sudo ubuntu-drivers install
 sudo reboot
+
 # Installation of drivers seems to install a full gnome desktop, and it seems to set up hibernation modes.
 # It is optional to run the below line (Hibernation may be something you want.)
-	sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+#   sudo systemctl mask sleep.target suspend.target hibernate.target hybrid-sleep.target
+
 sudo groupadd arm
 sudo useradd -m arm -g arm -G cdrom
-sudo passwd arm 
-  <enter new password>
+sudo passwd arm
+# <enter new password>
 ```
 
 **Set up repos and install dependencies**
 
 ```bash
-sudo apt-get install git -y
+sudo apt install -y git
 sudo add-apt-repository ppa:heyarje/makemkv-beta
 sudo add-apt-repository ppa:stebbins/handbrake-releases
 
 NumOnly=$(cut -f2 <<< `lsb_release -r`) && case $NumOnly in "16.04" ) sudo add-apt-repository ppa:mc3man/xerus-media;; "18.04" ) sudo add-apt-repository ppa:mc3man/bionic-prop;; "20.04" ) sudo add-apt-repository ppa:mc3man/focal6;; *) echo "error in finding release version";; esac
 
-sudo apt update -y && \
-sudo apt install makemkv-bin makemkv-oss -y && \
-sudo apt install handbrake-cli libavcodec-extra -y && \
-sudo apt install abcde flac imagemagick glyrc cdparanoia -y && \
-sudo apt install at -y && \
-sudo apt install python3 python3-pip -y && \
-sudo apt-get install libcurl4-openssl-dev libssl-dev -y && \
-sudo apt-get install libdvd-pkg -y && \
-sudo dpkg-reconfigure libdvd-pkg && \
-sudo apt install default-jre-headless -y
+sudo apt update && \
+sudo apt install -y makemkv-bin makemkv-oss && \
+sudo apt install -y handbrake-cli libavcodec-extra && \
+sudo apt install -y abcde flac imagemagick glyrc cdparanoia && \
+sudo apt install -y at && \
+sudo apt install -y python3 python3-pip && \
+sudo apt install -y libcurl4-openssl-dev libssl-dev && \
+sudo apt install -y default-jre-headless && \
+sudo apt install libdvd-pkg && \
+sudo dpkg-reconfigure libdvd-pkg
 ```
 
 **Install and setup ARM**
@@ -124,7 +139,7 @@ sudo chmod 775 arm
 sudo git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
 sudo chown -R arm:arm arm
 cd arm
-sudo pip3 install -r requirements.txt 
+sudo pip3 install -r requirements.txt
 sudo cp /opt/arm/setup/51-automedia.rules /etc/udev/rules.d/
 sudo ln -s /opt/arm/setup/.abcde.conf /home/arm/
 sudo cp docs/arm.yaml.sample arm.yaml
@@ -134,19 +149,21 @@ sudo ln -s /opt/arm/arm.yaml /etc/arm/
 
 **Set up drives**
 
-  Create mount point for each dvd drive.
-  If you don't know the device name try running `dmesg | grep -i -E '\b(dvd|cd)\b'`.  The mountpoint needs to be /mnt/dev/<device name>.
-  So if your device name is `sr0`, set the mountpoint with this command:
-  ```bash
-  sudo mkdir -p /mnt/dev/sr0
-  ```
-  Repeat this for each device you plan on using with ARM.
+Create mount point for each dvd drive.
+If you don't know the device name try running `dmesg | grep -i -E '\b(dvd|cd)\b'`.  The mountpoint needs to be /mnt/dev/<device name>.
+So if your device name is `sr0`, set the mountpoint with this command:
 
-  Create entries in /etc/fstab to allow non-root to mount dvd-roms
-  Example (create for each optical drive you plan on using for ARM):
-  ```
-  /dev/sr0  /mnt/dev/sr0  udf,iso9660  users,noauto,exec,utf8  0  0
-  ```
+```bash
+sudo mkdir -p /mnt/dev/sr0
+```
+
+Repeat this for each device you plan on using with ARM.
+
+Create entries in /etc/fstab to allow non-root to mount dvd-roms
+Example (create for each optical drive you plan on using for ARM):
+```
+/dev/sr0  /mnt/dev/sr0  udf,iso9660  users,noauto,exec,utf8  0  0
+```
 
 **Configure ARM**
 
@@ -156,99 +173,90 @@ sudo ln -s /opt/arm/arm.yaml /etc/arm/
 
 - To rip Blu-Rays after the MakeMKV trial is up you will need to purchase a license key or while MakeMKV is in BETA you can get a free key (which you will need to update from time to time) here:  https://www.makemkv.com/forum2/viewtopic.php?f=5&t=1053 and create /home/arm/.MakeMKV/settings.conf with the contents:
 
-        app_Key = "insertlicensekeyhere"
+    app_Key = "insertlicensekeyhere"
 
 - For ARM to identify movie/tv titles register for an API key at OMDb API: http://www.omdbapi.com/apikey.aspx and set the OMDB_API_KEY parameter in the config file.
 
 After setup is complete reboot...
-    
+
     reboot
 
-Optionally if you want something more stable than master you can download the latest release from the releases page.
+Optionally if you want something more stable than master, you can download the latest release from the releases page.
 
 **Email notifcations**
 
 A lot of random problems are found in the sysmail, email alerting is a most effective method for debugging and monitoring.
 
-I recommend you install postfix from here:http://mhawthorne.net/posts/2011-postfix-configuring-gmail-as-relay/
+I recommend you install postfix from here: http://mhawthorne.net/posts/2011-postfix-configuring-gmail-as-relay/
 
-Then configure /etc/aliases 
-	e.g.: 
-	
-	```	
-	root: my_email@gmail.com
-	arm: my_email@gmail.com
-	userAccount: my_email@gmail.com
-	```
-	
+Then configure `/etc/aliases` e.g.:
+
+```
+root: my_email@gmail.com
+arm: my_email@gmail.com
+userAccount: my_email@gmail.com
+```
+
 Run below to pick up the aliases
 
-	```
-	sudo newaliases
-	```
+```
+sudo newaliases
+```
 
-## Alternative Auto Install Script For OpenMediaVault/Debian
-**This MUST be run as root!**
-**For the attended install use:**
- ```
- apt install wget
- wget https://raw.githubusercontent.com/automatic-ripping-machine/automatic-ripping-machine/v2_master/scripts/debian-setup.sh
- chmod +x debian-setup.sh
- ./debian-setup.sh
- ```
- ```reboot``` 
- to complete installation.
- 
- 
- **For the silent install use**
-  ```
- apt -qqy install wget
- 
- wget https://raw.githubusercontent.com/automatic-ripping-machine/automatic-ripping-machine/v2_master/scripts/deb-install-quiet.sh
- chmod +x deb-install-quiet.sh
- ./deb-install-quiet.sh
- ```
-```reboot``` 
- to complete installation.
- **Details about this script**
- 
- The script installs all dependencies, a service for the ARMui and the fstab entry for sr0, if you have more than one drive you will need to make the mount folder and insert any additional fstab entries.
- The attended installer will do all of the necessary installs and deal with dependencies but will need user input.
- The silent install will remove the need for the user to interact with the screen after intering the arm userpassword.
- 
- 
- **The reason for the installer script ?**
- 
- The debian installer script has different commands than the ubuntu follow along commands. The reason being is that some of the commands that work on ubunutu dont work.
- You can also run each line of the script in a console or ssh terminal.
+## Upgrading to v2_master
 
+If you wish to upgrade to v2_master instead of a clean install, these directions should get you there.
 
-## Usage
+```bash
+cd /opt/arm
+sudo git checkout v2_master
+sudo pip3 install -r requirements.txt
+```
 
-- Insert disc
-- Wait for disc to eject
-- Repeat
+Backup config file and replace it with the updated config
+
+```bash
+mv arm.yaml arm.yaml.old
+cp docs/arm.yaml.sample arm.yaml
+```
+
+There are new config parameters so review the new arm.yaml file
+
+Make sure the 'arm' user has write permissions to the db directory (see your arm.yaml file for locaton). is writeable by the arm user.  A db will be created when you first run ARM.
+
+Make sure that your rules file is properly **copied** instead of linked:
+
+```
+sudo rm /usr/lib/udev/rules.d/51-automedia.rules
+sudo cp /opt/arm/setup/51-automedia.rules /etc/udev/rules.d/
+```
+
+Otherwise you may not get the auto-launching of ARM when a disc is inserted behavior
+on Ubuntu 20.04.
+
+Please log any issues you find.  Don't forget to run in DEBUG mode if you need to submit an issue (and log files).  Also, please note that you are running v2_master in your issue.
 
 ## Troubleshooting
 
 When a disc is inserted, udev rules should launch a script (scripts/arm_wrapper.sh) that will launch ARM.  Here are some basic troubleshooting steps:
-- Look for empty.log.  
+
+- Look for empty.log.
   - Everytime you eject the cdrom, an entry should be entered in empty.log like:
   ```
   [2018-08-05 11:39:45] INFO ARM: main.<module> Drive appears to be empty or is not ready.  Exiting ARM.
   ```
   - Empty.log should be in your logs directory as defined in your arm.yaml file.  If there is no empty.log file, or entries are not being entered when you eject the cdrom drive, then udev is not launching ARM correctly.  Check the instructions and make sure the symlink to 51-automedia.rules is set up right.  I've you've changed the link or the file contents you need to reload your udev rules with:
   ```
-  sudo udevadm control --reload-rules 
+  sudo udevadm control --reload-rules
   ```
 
-- Check ARM log files 
-  - The default location is /home/arm/logs/ (unless this is changed in your arm.yaml file) and is named after the dvd. These are very verbose.  You can filter them a little by piping the log through grep.  Something like 
+- Check ARM log files
+  - The default location is /home/arm/logs/ (unless this is changed in your arm.yaml file) and is named after the dvd. These are very verbose.  You can filter them a little by piping the log through grep.  Something like
   ```
   cat <logname> | grep ARM:
-  ```  
+  ```
     This will filter out the MakeMKV and HandBrake entries and only output the ARM log entries.
-  - You can change the verbosity in the arm.yaml file.  DEBUG will give you more information about what ARM is trying to do.  Note: please run a rip in DEBUG mode if you want to post to an issue for assistance.  
+  - You can change the verbosity in the arm.yaml file.  DEBUG will give you more information about what ARM is trying to do.  Note: please run a rip in DEBUG mode if you want to post to an issue for assistance.
   - Ideally, if you are going to post a log for help, please delete the log file, and re-run the disc in DEBUG mode.  This ensures we get the most information possible and don't have to parse the file for multiple rips.
 
 If you need any help feel free to open an issue.  Please see the above note about posting a log.

--- a/scripts/deb-install-quiet.sh
+++ b/scripts/deb-install-quiet.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# Install automatic-ripping-machine (ARM) silently on Debian.
+
 RED='\033[1;31m'
 NC='\033[0m' # No Color
 
@@ -39,25 +42,25 @@ make -s
 make install
 
 echo -e "${RED}Installing ffmpeg${NC}"
-apt -qq install ffmpeg -y
+apt -qqy install ffmpeg
 
 echo -e "${RED}Installing ARM requirments${NC}"
-apt -qq install handbrake-cli libavcodec-extra -y
-apt -qq install libdvdcss2 -y
-apt -qq install abcde flac imagemagick glyrc cdparanoia -y
-apt -qq install at -y
-apt -qq install python3 python3-pip -y
-apt -qq install libcurl4-openssl-dev libssl-dev -y
-apt -qq install libdvd-pkg -y
+apt -qqy install handbrake-cli libavcodec-extra
+apt -qqy install libdvdcss2
+apt -qqy install abcde flac imagemagick glyrc cdparanoia
+apt -qqy install at
+apt -qqy install python3 python3-pip
+apt -qqy install libcurl4-openssl-dev libssl-dev
+apt -qqy install libdvd-pkg
 wget -q http://download.videolan.org/pub/debian/stable/libdvdcss2_1.2.13-0_amd64.deb
 wget -q http://download.videolan.org/pub/debian/stable/libdvdcss_1.2.13-0.debian.tar.gz
 wget -q http://ftp.us.debian.org/debian/pool/contrib/libd/libdvd-pkg/libdvd-pkg_1.4.0-1-2_all.deb
 sudo dpkg -i libdvdcss2_1.2.13-0_amd64.deb 2> /dev/null
 sudo dpkg -i libdvd-pkg_1.4.0-1-2_all.deb 2> /dev/null
-apt -qq --fix-broken install -y
+apt -qq -f install -y
 dpkg-reconfigure libdvd-pkg 2> /dev/null
-apt -qq install default-jre-headless -y
-apt -qq install eject -y
+apt -qqy install default-jre-headless
+apt -qqy install eject
 
 echo -e "${RED}Installing ARM:Automatic Ripping Machine${NC}"
 cd /opt
@@ -67,10 +70,10 @@ chmod 775 arm
 git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
 chown -R arm:arm arm
 cd arm
-pip3 install setuptools
-apt -qq install python3-dev python3-pip python3-venv python3-wheel -y
-pip3 install wheel
-pip3 install -r requirements.txt 
+pip3 install -U setuptools
+apt -qqy install python3-dev python3-pip python3-venv python3-wheel
+pip3 install -U wheel
+pip3 install -r requirements.txt
 ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
 ln -s /opt/arm/setup/.abcde.conf /home/arm/
 cp docs/arm.yaml.sample arm.yaml
@@ -79,23 +82,23 @@ ln -s /opt/arm/arm.yaml /etc/arm/
 
 mkdir -p /mnt/dev/sr0
 
-######## adding new line to fstab, needed for the autoplay to work
+######## Adding new line to fstab, needed for the autoplay to work.
 echo -e "${RED}Adding fstab entry${NC}"
 echo -e "\n/dev/sr0  /mnt/dev/sr0  udf,iso9660  user,noauto,exec,utf8  0  0 \n" >> /etc/fstab
 
-#####run the ARM ui as a service
+##### Run the ARM ui as a service.
 echo -e "${RED}Installing ARM service${NC}"
 cat > /etc/systemd/system/armui.service <<- EOM
 [Unit]
 Description=Arm service
-## Added to force armui to wait for network
+## Added to force armui to wait for network.
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-## Add your path to your logfiles if you want to enable logging
-## Remember to remove the # at the start of the line
+## Add your path to your logfiles if you want to enable logging.
+## Remember to remove the # at the start of the line.
 #StandardOutput=append:/PATH-TO-MY-LOGFILES/WebUI.log
 #StandardError=append:/PATH-TO-MY-LOGFILES/WebUI.log
 Restart=always
@@ -106,7 +109,7 @@ ExecStart=python3 /opt/arm/arm/runui.py
 WantedBy=multi-user.target
 EOM
 
-#reload the daemon and then start ui
+# Reload the daemon and then start UI.
 systemctl enable armui
 systemctl start armui
 systemctl daemon-reload

--- a/scripts/deb-install-quiet.sh
+++ b/scripts/deb-install-quiet.sh
@@ -33,13 +33,13 @@ wget -q https://www.makemkv.com/download/makemkv-sha-$mmv.txt
 wget -q https://www.makemkv.com/download/makemkv-bin-$mmv.tar.gz
 wget -q https://www.makemkv.com/download/makemkv-oss-$mmv.tar.gz
 
-echo "${RED}Checking checksums${NC}"
+echo -e "${RED}Checking checksums${NC}"
 grep "makemkv-bin-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c
 # grep "makemkv-oss-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c  # DEBUG
 # Their makemkv-oss-1.16.3.tar.gz checksum did not match???
 # Remove these comments and enable the grep line above when it does match.
 
-echo "${RED}Extracting MakeMKV${NC}"
+echo -e "${RED}Extracting MakeMKV${NC}"
 tar xzf makemkv-oss-$mmv.tar.gz
 tar xzf makemkv-bin-$mmv.tar.gz
 

--- a/scripts/deb-install-quiet.sh
+++ b/scripts/deb-install-quiet.sh
@@ -22,7 +22,7 @@ apt -qqy install build-essential pkg-config libc6-dev libssl-dev libexpat1-dev l
 #apt -qqy install wget
 
 echo -e "${RED}Setting up directories and getting makeMKV files${NC}"
-mkdir /makeMKV
+mkdir -p /makeMKV
 cd /makeMKV
 
 echo -e "${RED}Finding current MakeMKV version${NC}"
@@ -50,8 +50,8 @@ make -s
 make install
 
 cd ../makemkv-bin-$mmv
-mkdir /makeMKV/makemkv-bin-1.16.1/tmp
-touch /makeMKV/makemkv-bin-1.16.1/tmp/eula_accepted
+mkdir -p /makeMKV/makemkv-bin-$mmv/tmp
+touch /makeMKV/makemkv-bin-$mmv/tmp/eula_accepted
 make -s
 make install
 
@@ -78,7 +78,7 @@ apt -qqy install eject
 
 echo -e "${RED}Installing ARM:Automatic Ripping Machine${NC}"
 cd /opt
-mkdir arm
+mkdir -p arm
 chown arm:arm arm
 chmod 775 arm
 git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
@@ -91,7 +91,7 @@ pip3 install -r requirements.txt
 ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
 ln -s /opt/arm/setup/.abcde.conf /home/arm/
 cp docs/arm.yaml.sample arm.yaml
-mkdir /etc/arm/
+mkdir -p /etc/arm/
 ln -s /opt/arm/arm.yaml /etc/arm/
 
 mkdir -p /mnt/dev/sr0

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -2,6 +2,9 @@
 
 # Setup automatic-ripping-machine (ARM) for Debian systems.
 
+# Exit on error.
+set -e
+
 RED='\033[1;31m'
 NC='\033[0m' # No Color
 
@@ -21,20 +24,31 @@ echo -e "${RED}Setting up directories and getting makeMKV files${NC}"
 mkdir /makeMKV
 cd /makeMKV
 
-wget https://www.makemkv.com/download/old/makemkv-bin-1.16.1.tar.gz
-wget https://www.makemkv.com/download/old/makemkv-oss-1.16.1.tar.gz
+echo -e "${RED}Finding current MakeMKV version${NC}"
+mmv=$(curl -s https://www.makemkv.com/download/ | grep -o [0-9.]*.txt | sed 's/.txt//')
 
-echo -e "${RED}Extracting MakeMKV${NC}"
-tar xvzf makemkv-oss-1.16.1.tar.gz
-tar xvzf makemkv-bin-1.16.1.tar.gz
+echo -e "${RED}Downloading MakeMKV sha, bin, and oss${NC}"
+wget https://www.makemkv.com/download/makemkv-sha-$mmv.txt
+wget https://www.makemkv.com/download/makemkv-bin-$mmv.tar.gz
+wget https://www.makemkv.com/download/makemkv-oss-$mmv.tar.gz
 
-cd makemkv-oss-1.16.1
+echo "${RED}Checking checksums${NC}"
+grep "makemkv-bin-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c
+# grep "makemkv-oss-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c  # DEBUG
+# Their makemkv-oss-1.16.3.tar.gz checksum did not match???
+# Remove these comments and enable the grep line above when it does match.
+
+echo "${RED}Extracting MakeMKV${NC}"
+tar xvzf makemkv-oss-$mmv.tar.gz
+tar xvzf makemkv-bin-$mmv.tar.gz
+
+cd makemkv-oss-$mmv
 echo -e "${RED}Installing MakeMKV${NC}"
 ./configure
 make
 make install
 
-cd ../makemkv-bin-1.16.1
+cd ../makemkv-bin-$mmv
 make
 make install
 

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+# Setup automatic-ripping-machine (ARM) for Debian systems.
+
 RED='\033[1;31m'
 NC='\033[0m' # No Color
 
@@ -7,11 +10,12 @@ groupadd arm
 useradd -m arm -g arm -G cdrom
 passwd arm
 echo -e "${RED}Installing git${NC}"
-apt-get install git
+apt update
+apt install -y git
 echo -e "${RED}Installing required build tools${NC}"
-apt-get install build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qtbase5-dev zlib1g-dev
+apt install -y build-essential pkg-config libc6-dev libssl-dev libexpat1-dev libavcodec-dev libgl1-mesa-dev qtbase5-dev zlib1g-dev
 echo -e "${RED}Installing wget${NC}"
-apt-get install wget
+apt install -y wget
 
 echo -e "${RED}Setting up directories and getting makeMKV files${NC}"
 mkdir /makeMKV
@@ -35,25 +39,25 @@ make
 make install
 
 echo -e "${RED}Installing ffmpeg${NC}"
-apt install ffmpeg
+apt install -y ffmpeg
 
 echo -e "${RED}Installing ARM requirments${NC}"
-apt install handbrake-cli libavcodec-extra
-apt install libdvdcss2
-apt install abcde flac imagemagick glyrc cdparanoia
-apt install at
-apt install python3 python3-pip
-apt install libcurl4-openssl-dev libssl-dev  
-apt install libdvd-pkg
+apt install -y handbrake-cli libavcodec-extra
+apt install -y libdvdcss2
+apt install -y abcde flac imagemagick glyrc cdparanoia
+apt install -y at
+apt install -y python3 python3-pip
+apt install -y libcurl4-openssl-dev libssl-dev
+apt install -y libdvd-pkg
 wget http://download.videolan.org/pub/debian/stable/libdvdcss2_1.2.13-0_amd64.deb
 wget http://download.videolan.org/pub/debian/stable/libdvdcss_1.2.13-0.debian.tar.gz
 wget http://ftp.us.debian.org/debian/pool/contrib/libd/libdvd-pkg/libdvd-pkg_1.4.0-1-2_all.deb
 sudo dpkg -i libdvdcss2_1.2.13-0_amd64.deb
 sudo dpkg -i libdvd-pkg_1.4.0-1-2_all.deb
-apt --fix-broken install
+apt -f install
 dpkg-reconfigure libdvd-pkg
-apt install default-jre-headless
-apt install eject
+apt install -y default-jre-headless
+apt install -y eject
 
 echo -e "${RED}Installing ARM:Automatic Ripping Machine${NC}"
 cd /opt
@@ -63,10 +67,10 @@ chmod 775 arm
 git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
 chown -R arm:arm arm
 cd arm
-pip3 install setuptools
-apt-get install python3-dev python3-pip python3-venv python3-wheel -y
-pip3 install wheel
-pip3 install -r requirements.txt 
+pip3 install -U setuptools
+apt install -y python3-dev python3-pip python3-venv python3-wheel
+pip3 install -U wheel
+pip3 install -r requirements.txt
 ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
 ln -s /opt/arm/setup/.abcde.conf /home/arm/
 cp docs/arm.yaml.sample arm.yaml
@@ -75,23 +79,23 @@ ln -s /opt/arm/arm.yaml /etc/arm/
 
 mkdir -p /mnt/dev/sr0
 
-######## adding new line to fstab, needed for the autoplay to work
+######## Adding new line to fstab, needed for the autoplay to work.
 echo -e "${RED}Adding fstab entry${NC}"
 echo -e "\n/dev/sr0  /mnt/dev/sr0  udf,iso9660  user,noauto,exec,utf8  0  0 \n" >> /etc/fstab
 
-#####run the ARM ui as a service
+##### Run the ARM UI as a service.
 echo -e "${RED}Installing ARM service${NC}"
 cat > /etc/systemd/system/armui.service <<- EOM
 [Unit]
 Description=Arm service
-## Added to force armui to wait for network
+## Added to force armui to wait for network.
 After=network-online.target
 Wants=network-online.target
 
 [Service]
 Type=simple
-## Add your path to your logfiles if you want to enable logging
-## Remember to remove the # at the start of the line
+## Add your path to your logfiles if you want to enable logging.
+## Remember to remove the # at the start of the line.
 #StandardOutput=append:/PATH-TO-MY-LOGFILES/WebUI.log
 #StandardError=append:/PATH-TO-MY-LOGFILES/WebUI.log
 Restart=always
@@ -102,8 +106,7 @@ ExecStart=python3 /opt/arm/arm/runui.py
 WantedBy=multi-user.target
 EOM
 
-#reload the daemon and then start ui
+# Reload the daemon and then start UI.
 systemctl enable armui
 systemctl start armui
 systemctl daemon-reload
-

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -32,13 +32,13 @@ wget https://www.makemkv.com/download/makemkv-sha-$mmv.txt
 wget https://www.makemkv.com/download/makemkv-bin-$mmv.tar.gz
 wget https://www.makemkv.com/download/makemkv-oss-$mmv.tar.gz
 
-echo "${RED}Checking checksums${NC}"
+echo -e "${RED}Checking checksums${NC}"
 grep "makemkv-bin-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c
 # grep "makemkv-oss-$mmv.tar.gz" makemkv-sha-$mmv.txt | sha256sum -c  # DEBUG
 # Their makemkv-oss-1.16.3.tar.gz checksum did not match???
 # Remove these comments and enable the grep line above when it does match.
 
-echo "${RED}Extracting MakeMKV${NC}"
+echo -e "${RED}Extracting MakeMKV${NC}"
 tar xvzf makemkv-oss-$mmv.tar.gz
 tar xvzf makemkv-bin-$mmv.tar.gz
 

--- a/scripts/debian-setup.sh
+++ b/scripts/debian-setup.sh
@@ -21,7 +21,7 @@ echo -e "${RED}Installing wget${NC}"
 apt install -y wget
 
 echo -e "${RED}Setting up directories and getting makeMKV files${NC}"
-mkdir /makeMKV
+mkdir -p /makeMKV
 cd /makeMKV
 
 echo -e "${RED}Finding current MakeMKV version${NC}"
@@ -75,7 +75,7 @@ apt install -y eject
 
 echo -e "${RED}Installing ARM:Automatic Ripping Machine${NC}"
 cd /opt
-mkdir arm
+mkdir -p arm
 chown arm:arm arm
 chmod 775 arm
 git clone https://github.com/automatic-ripping-machine/automatic-ripping-machine.git arm
@@ -88,7 +88,7 @@ pip3 install -r requirements.txt
 ln -s /opt/arm/setup/51-automedia.rules /lib/udev/rules.d/
 ln -s /opt/arm/setup/.abcde.conf /home/arm/
 cp docs/arm.yaml.sample arm.yaml
-mkdir /etc/arm/
+mkdir -p /etc/arm/
 ln -s /opt/arm/arm.yaml /etc/arm/
 
 mkdir -p /mnt/dev/sr0


### PR DESCRIPTION
Changes in this PR:

- Automated installation of latest MakeMKV.
  - Added parsing for the latest MakeMKV version instead of relying on hardcoding version numbers.
  - Added checksum verification for MakeMKV download.
- Cleaned up the README.
  - Reordered headings in the README to describe the project and how it works first.  Installation steps follow starting with automated install, then manual install, and then upgrade.
  - Cleaned up references to version 2.2 which does not exist in this repo.  Fixes some of this issue: https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/393
- Minor edits to README and BASH scripts.
  - Added exit on error to BASH scripts.
  - Changed `apt-get` to `apt`.
  - Added or moved `-y` flags to every `apt` command before or after `install` so further edits can be done with vertical editing.
  - Added periods to sentences.
  - Added a space before sentences in comments.
  - Removed blank space at the end of lines if I came across it.
  - Added carriage returns to make the README markdown easier to read.
  - Added `-p` to `mkdir` commands so they do not fail if the directory already exists.