### PR TITLE
Fixed Error in log and folder names

### DIFF
--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -187,6 +187,7 @@ def identify_dvd(job):
     logging.debug("dvd_title ^a-z= " + str(dvd_title))
     # rip out any SKU's at the end of the line
     dvd_title = re.sub("SKU$", " ", dvd_title)
+    dvd_title = dvd_title.strip()
     logging.debug("dvd_title SKU$= " + str(dvd_title))
 
     # try to contact omdb

--- a/arm/ripper/logger.py
+++ b/arm/ripper/logger.py
@@ -42,7 +42,7 @@ def setuplogging(job):
             newlogfile = str(job.label) + "_" + str(round(time.time() * 100)) + ".log"
             TmpLogFull = cfg['LOGPATH'] + logfile
             logfile = newlogfile if os.path.isfile(TmpLogFull) else logfile
-            logfull = cfg['LOGPATH'] + newlogfile if os.path.isfile(TmpLogFull) else cfg['LOGPATH'] + str(job.label) + ".log "
+            logfull = cfg['LOGPATH'] + newlogfile if os.path.isfile(TmpLogFull) else cfg['LOGPATH'] + str(job.label) + ".log"
         else:
             # Check to see if file already exists, if so, create a new file
             newlogfile = str(job.label) + "_" + str(round(time.time() * 100)) + ".log"


### PR DESCRIPTION
Fixed an error with some log files splitting during ripping, due to a trailing white space "*.log "
Fixed an error with folder names being created with trailing white space when not identified

Fixes issue #445 