### PR TITLE
Additional logic for TV-Series - subfolders per disk, removes need for duplicate rips to be enabled

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -185,7 +185,7 @@ def main(logfile, job):
                 hboutpath = os.path.join(job.config.MEDIA_DIR, str(job.title))
         else:
             hboutpath = os.path.join(job.config.ARMPATH, str(job.title))
-        # if tv series include the disk label in name. usually contains DISK1, DISK2 etc. 
+        # if tv series, include the disk label in folder path. usually contains DISK1, DISK2 etc. 
         # this means duplicate rips does not need to be enabled
         if job.video_type == "series":
             hboutpath = os.path.join(hboutpath, str(job.label))

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -185,6 +185,10 @@ def main(logfile, job):
                 hboutpath = os.path.join(job.config.MEDIA_DIR, str(job.title))
         else:
             hboutpath = os.path.join(job.config.ARMPATH, str(job.title))
+        # if tv series include the disk label in name. usually contains DISK1, DISK2 etc. 
+        # this means duplicate rips does not need to be enabled
+        if job.video_type == "series":
+            hboutpath = os.path.join(hboutpath, str(job.label))
 
         #  The dvd directory already exists - Lets make a new one using random numbers
         if (utils.make_dir(hboutpath)) is False:

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -40,6 +40,9 @@ def makemkv(logfile, job):
         raise RuntimeError(err)
 
     # get filesystem in order
+
+    # if tv series, include the disk label in folder path. usually contains DISK1, DISK2 etc. 
+    # this means duplicate rips does not need to be enabled
     if job.video_type == "series":
         rawpath = os.path.join(str(job.config.RAWPATH), str(job.title) + "__" +str(job.label))
     else:

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -40,7 +40,10 @@ def makemkv(logfile, job):
         raise RuntimeError(err)
 
     # get filesystem in order
-    rawpath = os.path.join(str(job.config.RAWPATH), str(job.title))
+    if job.video_type == "series":
+        rawpath = os.path.join(str(job.config.RAWPATH), str(job.title))
+    else:
+        rawpath = os.path.join(str(job.config.RAWPATH), str(job.title) + "__" +str(job.label))
     logging.info("Destination is " + str(rawpath))
 
     if not os.path.exists(rawpath):

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -41,9 +41,9 @@ def makemkv(logfile, job):
 
     # get filesystem in order
     if job.video_type == "series":
-        rawpath = os.path.join(str(job.config.RAWPATH), str(job.title))
-    else:
         rawpath = os.path.join(str(job.config.RAWPATH), str(job.title) + "__" +str(job.label))
+    else:
+        rawpath = os.path.join(str(job.config.RAWPATH), str(job.title))
     logging.info("Destination is " + str(rawpath))
 
     if not os.path.exists(rawpath):

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -885,6 +885,10 @@ def rename_files(oldpath, job):
     """
 
     newpath = os.path.join(job.config.ARMPATH, job.title + " (" + str(job.year) + ")")
+    # if tv series, include the disk label in name. usually contains DISK1, DISK2 etc. 
+    # this means duplicate rips does not need to be enabled
+    if job.video_type == "series":
+        newpath = os.path.join(newpath, str(job.label))
     logging.debug("oldpath: " + oldpath + " newpath: " + newpath)
     logging.info("Changing directory name from " + oldpath + " to " + newpath)
 

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -885,7 +885,7 @@ def rename_files(oldpath, job):
     """
 
     newpath = os.path.join(job.config.ARMPATH, job.title + " (" + str(job.year) + ")")
-    # if tv series, include the disk label in name. usually contains DISK1, DISK2 etc. 
+    # if tv series, include the disk label in folder path. usually contains DISK1, DISK2 etc. 
     # this means duplicate rips does not need to be enabled
     if job.video_type == "series":
         newpath = os.path.join(newpath, str(job.label))


### PR DESCRIPTION
removes need for duplicate rips to be enabled.
allows ripping of multiple disks from the same series at the same time without overwriting of files

Will only rip a series disk once as it will detect the duplicate if it exists

example of folder structure on a tv show with disk titles CAPRICA_DISC1 + CAPRICA_DISC2
```
'/home/arm/media/movies/Caprica (2009–2010)/CAPRICA_DISC1/title_01.mkv'
'/home/arm/media/movies/Caprica (2009–2010)/CAPRICA_DISC1/title_02.mkv'
'/home/arm/media/movies/Caprica (2009–2010)/CAPRICA_DISC2/title_01.mkv'
'/home/arm/media/movies/Caprica (2009–2010)/CAPRICA_DISC2/title_02.mkv'
```