### PR TITLE
Remove space after logfile name

### DIFF
--- a/arm/ripper/logger.py
+++ b/arm/ripper/logger.py
@@ -42,7 +42,7 @@ def setuplogging(job):
             newlogfile = str(job.label) + "_" + str(round(time.time() * 100)) + ".log"
             TmpLogFull = cfg['LOGPATH'] + logfile
             logfile = newlogfile if os.path.isfile(TmpLogFull) else logfile
-            logfull = cfg['LOGPATH'] + newlogfile if os.path.isfile(TmpLogFull) else cfg['LOGPATH'] + str(job.label) + ".log "
+            logfull = cfg['LOGPATH'] + newlogfile if os.path.isfile(TmpLogFull) else cfg['LOGPATH'] + str(job.label) + ".log"
         else:
             # Check to see if file already exists, if so, create a new file
             newlogfile = str(job.label) + "_" + str(round(time.time() * 100)) + ".log"


### PR DESCRIPTION
I get logfiles with spaces after them. This may fix it.

Example of current logfiles:
```
arm@ubuntu:/home/arm/logs# ls -la
total 24
drwxrwxr-x 2 arm arm 4096 nov 29 22:43  .
drwxr-xr-x 7 arm arm 4096 nov 29 21:11  ..
-rw-rw-r-- 1 arm arm   81 nov 29 22:43 'cdrom_backups.log '
-rw-rw-r-- 1 arm arm   98 nov 29 21:12  CDROM.log
-rw-rw-r-- 1 arm arm 3509 nov 29 21:12 'CDROM.log '
-rw-rw-r-- 1 arm arm 3367 nov 29 22:44  empty.log
```
