### PR TITLE
Add backup_dvd and HANDBRAKE_LOCAL cfg options.

### DIFF
--- a/arm/ripper/handbrake.py
+++ b/arm/ripper/handbrake.py
@@ -241,7 +241,7 @@ def get_track_info(srcpath, job):
     """
     logging.info("Using HandBrake to get information on all the tracks on the disc.  This will take a few minutes...")
 
-    cmd = f'{cfg["HANDBRAKE_CLI"]} -i {shlex.quote(srcpath)} -t 0 --scan'
+    cmd = f'{cfg["HANDBRAKE_LOCAL"]} -i {shlex.quote(srcpath)} -t 0 --scan'
 
     logging.debug(f"Sending command: {cmd}")
     hb = handbrake_char_encoding(cmd)

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -271,7 +271,7 @@ def main(logfile, job):
         # or
         # dvd with MAINFEATURE off and RIPMETHOD mkv
         hb_in_path = str(job.devpath)
-        if job.disctype == "bluray" or (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv"):
+        if job.disctype == "bluray" or (not cfg["MAINFEATURE"] and cfg["RIPMETHOD"] == "mkv") or cfg["RIPMETHOD"] == "backup_dvd":
             # send to makemkv for ripping
             # run MakeMKV and get path to output
             job.status = "ripping"

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -52,7 +52,7 @@ def makemkv(logfile, job):
     rawpath = setup_rawpath(job, os.path.join(str(cfg["RAW_PATH"]), str(job.title)))
 
     # rip bluray
-    if cfg["RIPMETHOD"] == "backup" and job.disctype == "bluray":
+    if (cfg["RIPMETHOD"] == "backup" or cfg["RIPMETHOD"] == "backup_dvd") and job.disctype == "bluray":
         # backup method
         cmd = f'makemkvcon backup --decrypt {cfg["MKV_ARGS"]} ' \
               f'-r disc:{mdisc.strip()} {shlex.quote(rawpath)}>> {logfile}'

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -173,11 +173,12 @@ CHOWN_GROUP:
 ## MakeMKV Parameters ##
 ########################
 
-# Method of MakeMKV to use for Blu Ray discs.  Options are "mkv" or "backup".
-# backup decrypts the dvd and then copies it to the hard drive.  This allows HandBrake to apply some of it's
+# Method of MakeMKV to use for Blu Ray discs.  Options are "mkv",  "backup" or "backup_dvd".
+# backup decrypts the bluray and then copies it to the hard drive.  This allows HandBrake to apply some of it's
 # analytical abilities such as the main-feature identification.  This method seems to offer success on bluray 
-# discs that fail in "mkv" mode. *** NOTE: MakeMKV only supports the backup method on BluRay discs.  ARM does
-# not use MakeMKV for DVDs.   
+# discs that fail in "mkv" mode.
+# *** NOTE: MakeMKV only supports the backup method on BluRay discs.
+# backup_dvd forces arm to extract the dvd with MakeMKV prior to the Handbrake step
 RIPMETHOD: "backup"
 
 # MakeMKV Arguments
@@ -212,8 +213,10 @@ HB_PRESET_BD: "HQ 1080p30 Surround"
 # Extension of the final video file
 DEST_EXT: mkv
 
-# Handbrake binary to call
+# Handbrake binary to call.  These should be the same unless you are doing remote
+# processing.
 HANDBRAKE_CLI: HandBrakeCLI
+HANDBRAKE_LOCAL: HandBrakeCLI
 
 # Have HandBrake transcode the main feature only.  BluRay discs must have RIPMETHOD="backup" for this to work.
 # If MAINFEATURE is true, blurays will be backed up to the HD and then HandBrake will go to work on the backed up


### PR DESCRIPTION
# Description
Bring back old ARM style of using MakeMKV to copy DVD's to the HD prior
to transcode (with option backup_dvd).  Add a HANDBRAKE_LOCAL option.  With these two, I can run
ARM semi-distributed via Slurm.  It also allows you to do something like:
HANDBRAKE_CLI: ssh hostname HandBrakeCLI
If you just want to do the transcode on a single remote host.

This opens the door to potentially being able to do fully distributed transcoding, for now, it just does 1 disc per remote host.  This is basically step 1 in order to do #94  I suspect step 2 is to pull in the python slurm library, which may or may not be far too heavyweight.

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

Installed slurm_client on host with bluray player.  Built 2 VM's with a slurm cluster.  Set HANDBRAKE_CLI to "srun --exclusive HandBrakeCLI" and RIPMETHOD to "backup_dvd".  Insert 2 discs, and it distributed the transcoding into the cluster.  (with generous amounts of NFS sprinkled in).

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [X] Debian 10
- [X] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
