### PR TITLE
Fix tablesorter using wrong column for sorting

### DIFF
--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -490,7 +490,7 @@ def history():
     if os.path.isfile(cfg['DBFILE']):
         # after roughly 175 entries firefox readermode will break
         # jobs = Job.query.filter_by().limit(175).all()
-        jobs = Job.query.order_by().paginate(page, 100, False)
+        jobs = Job.query.order_by(Job.start_time.desc()).paginate(page, 100, False)
     else:
         app.logger.error('ERROR: /history database file doesnt exist')
         jobs = {}

--- a/arm/ui/templates/history.html
+++ b/arm/ui/templates/history.html
@@ -83,6 +83,10 @@
             content: "Logfile:\A";
         }
     }
+
+    .hidden {
+        display: none;
+    }
 </style>
 <div class="container content">
     <div class="row">
@@ -138,6 +142,7 @@
                                     job.title|truncate(50, True) if job.title is not none else 'Title unknown' }}</a>
                                 </th>
                                 <td>{{ job.start_time.strftime(date_format) if job.start_time is not none }}</td>
+                                <td class="hidden">{{ job.start_time if job.start_time is not none }}</td>
                                 <td>{{ job.job_length }}</td>
                                 <td class="{{ job.status }}"><img src="static/img/{{ job.status }}.png" height="30px"
                                                                   width="30px" alt="{{ job.status }}"
@@ -163,8 +168,8 @@
         $(document).ready(function () {
             // call the tablesorter plugin
             $("table").tablesorter({
-                // sort on the first column and third column, order asc
-                sortList: [[1, 1]]
+                // sort on the third column (startime, no format)
+                sortList: [[2, 1]]
             });
         });
         activeTab("history");


### PR DESCRIPTION
# Description

This allows tablesorter to use a non localized  timestring to sort the table. Otherwise it messes around with the order and breaks.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?


- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
