### PR TITLE
Adds umask option

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -181,6 +181,10 @@ def main(logfile, job):
 
     utils.notify_entry(job)
 
+    if cfg["UMASK"]:
+        logging.info(f"Setting umask to {cfg['UMASK']}")
+        os.umask(int(cfg["UMASK"], 8))
+
     #  If we have have waiting for user input enabled
     if cfg["MANUAL_WAIT"]:
         logging.info(f"Waiting {cfg['MANUAL_WAIT_TIME']} seconds for manual override.")

--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -15,6 +15,7 @@
     "ARM_CHILDREN": "# Comma delimited list of child ARM servers to display on the Home Page\n# Should be full protocol, path, and port: http://192.168.0.100:8080/",
     "PREVENT_99": "# Prevent ARM from wasting time on 99 Title protected DVDs.\n# A DRM scheme used on some DVDs which creates fake titles which confuses Handbrake.\n# When set to \"true\" affected DVDs will be autoejected on insertion.",
     "ARM_CHECK_UDF": "# Distinguish UDF video discs from UDF data discs.  Requires mounting disc so adds a few seconds to the identify script.",
+    "UMASK": "# Umask for created files (in RAW_PATH, TRANSCODE_PATH, and COMPLETED_PATH). # Setting this to 0o002 (octal) makes these files group writable. # For general information about umask, see for example https://en.wikipedia.org/wiki/Umask",
     "GET_VIDEO_TITLE": "# When enabled if the disc is a DVD use dvdid to calculate a crc64 and query Windows Media Meta Services for the Movie Title.\n# For BluRays attempts to extract the title from an XML file on the disc",
     "ARM_API_KEY": "# ARM dvd crc64 api key\n# This is only needed if you would like to send movies to the database",
     "DISABLE_LOGIN": "# Do you want to be forced to login to view/edit jobs\n# True will leave all of the pages open to be editable/viewable by anyone\n# False will require you to login to view/edit jobs or settings from the ui\n# ARMui will need to be restared for this to update",

--- a/docs/arm.yaml.sample
+++ b/docs/arm.yaml.sample
@@ -21,6 +21,11 @@ PREVENT_99: true
 # Distinguish UDF video discs from UDF data discs.  Requires mounting disc so adds a few seconds to the identify script.
 ARM_CHECK_UDF: true
 
+# Umask for created files (in RAW_PATH, TRANSCODE_PATH, and COMPLETED_PATH).
+# Setting this to 0o002 (octal) makes these files group writable.
+# For general information about umask, see for example https://en.wikipedia.org/wiki/Umask
+UMASK: 0o002
+
 # When enabled if the disc is a DVD use dvdid to calculate a crc64 and query Windows Media Meta Services for the Movie Title.
 # For BluRays attempts to extract the title from an XML file on the disc
 GET_VIDEO_TITLE: true


### PR DESCRIPTION
# Description

This PR adds a umask configuration option. Using this option the files output by arm can be made to be group writable so that users on the system that are in the arm group can delete/move/rename the ripped files as desired. This means that root/sudo is not needed, and also that the arm users shell can be set /sbin/nologin enhancing security.

The umask setting is used in the ripper arm/ripper/main.py but not in the web armui.py

I note that there is CHMOD_VALUE which seems to exist to solve the same problem. However, I think this is a far simpler and more powerful solution. If this PR is accepted, I would suggest removing the CHMOD_VALUE option.

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've been using this option with it set to 0o002. The ripper runs as user arm which has primary group arm. Files and directories produced by the ripper (RAW_PATH, TRANSCODE_PATH, and COMPLETED_PATH) are indeed all group writable as expect. My normal user is a member of the arm group and can move/delete the files produced.

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [x] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
      The code is short, readable and seems not to warrant an explicit comment
- [x] I have made corresponding changes to the documentation
      The option is documented in the `docs/arm.yaml.sample`
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
