### PR TITLE
Adds optional config file locations

### DIFF
--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -3,10 +3,17 @@
 import os
 import yaml
 
-yamlfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..", "arm.yaml")
+default_yamlfile = os.path.join(os.path.dirname(os.path.abspath(__file__)), "../..", "arm.yaml")
 
-with open(yamlfile, "r") as f:
-    try:
-        cfg = yaml.load(f, Loader=yaml.FullLoader)
-    except Exception:
-        cfg = yaml.safe_load(f)  # For older versions use this
+for yamlfile in [os.path.expanduser('~/.config/arm/arm.yaml'),
+                 '/etc/arm/arm.yaml', default_yamlfile]:
+    if not os.path.exists(yamlfile):
+        continue
+
+    with open(yamlfile, "r") as f:
+        try:
+            cfg = yaml.load(f, Loader=yaml.FullLoader)
+        except Exception:
+            cfg = yaml.safe_load(f)  # For older versions use this
+
+        break


### PR DESCRIPTION
# Description

This PR allows the user to choose between three options for the arm.yaml config file. `arm/config/config.py` first tries reading the config from `~/.config/arm/arm.yaml`, then `/etc/arm/arm.yaml` before finally falling back to the `arm.yaml` in the source directory.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I've used this by running the ripper and the armui with the config `/etc/arm/arm.yaml` and another time in `/home/arm/.config/arm.yaml`.

Interestingly, arm_wrapper.sh expects the config to be in `/etc/arm` whereas the existing python code expects it to be in the source tree. I have a modified version of arm_wrapper.sh that searches the same paths as this updated `config.py`, but it has additional features, so that will be in a separate PR.

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [x] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
      The changes are very minor, and I think it is clear what code is doing
      without explicit comments.
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
