### PR TITLE
Update docker-setup.sh

### DIFF
--- a/scripts/installers/docker-setup.sh
+++ b/scripts/installers/docker-setup.sh
@@ -71,6 +71,7 @@ function setup_mountpoints() {
     for dev in /dev/sr?; do
         sudo mkdir -p "/mnt$dev"
     done
+    sudo chown arm:arm /mnt/dev/sr*
 }
 
 function save_start_command() {

--- a/scripts/installers/docker-setup.sh
+++ b/scripts/installers/docker-setup.sh
@@ -69,7 +69,7 @@ function pull_image() {
 function setup_mountpoints() {
     echo -e "${RED}Creating mount points${NC}"
     for dev in /dev/sr?; do
-        sudo -u arm mkdir -p "/mnt$dev"
+        sudo mkdir -p "/mnt$dev"
     done
 }
 


### PR DESCRIPTION
# Description

Change user to address permissions failure during setup_mountpoints
Issue #564

The mkdir command was being run as 'arm' user, therefore it failed.
Removed the --user option to run as 'arm' user so it runs as sudo


Fixes #564 docker install fails to mount

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I updated the script with the proposed fix and then restarted the script from where it errored out.

1. Edited docker-setup.sh with the proposed changes
2. Commented out the function calls before setup_mountpoints
3. Re-ran edited script as per wiki:
sudo ./docker-setup.sh

Edited script then completed successfully
Terminal output:
Creating mount points
Installation complete. A template command to run the ARM container is located in: /home/arm


Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ X] Other (Please state here)
Ubuntu 22.04
Fresh install: Desktop, minimal, non-free

# Checklist:

- [X ] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [ ] My code follows the style guidelines of this project
- [X ] I have performed a self-review of my own code
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X ] My changes generate no new warnings
- [ X] I have tested that my fix is effective or that my feature works
