### PR TITLE
Update start_arm_container.sh

### DIFF
--- a/scripts/docker/start_arm_container.sh
+++ b/scripts/docker/start_arm_container.sh
@@ -15,4 +15,4 @@ docker run -d \
     --privileged \
     --restart "always" \
     --name "arm-rippers" \
-    --cpuset-cpus='2,3,4,5,6,7...'
+    --cpuset-cpus='2,3,4,5,6,7...' \


### PR DESCRIPTION
Missing new line slash

# Description

Added new line slash.
Script was erroring out before.
Terminal output:
```
sudo ./start_arm_container.sh                     
"docker run" requires at least 1 argument.                                                                                                            
See 'docker run --help'.                                                                                                                              
                                                                                                                                                      
Usage:  docker run [OPTIONS] IMAGE [COMMAND] [ARG...]                                                                                                 

Run a command in a new container
./start_arm_container.sh: line 17: automaticrippingmachine/automatic-ripping-machine:latest: No such file or directory

```
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes # (didn't open issue)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I edited the file locally with the proposed changes.
Then the script ran and started as expected.

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [X] Docker
- [X Other (Please state here)
Ubuntu 22.04

# Checklist:

- [X] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
