### PR TITLE
Update arm.yaml

### DIFF
--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -182,7 +182,7 @@ CHOWN_GROUP:
 # This method seems to offer success on Blu-ray discs that fail in "mkv" mode.
 # *** NOTE: MakeMKV only supports the backup or backup_dvd method on BluRay discs.
 # backup_dvd forces arm to extract the dvd with MakeMKV prior to the Handbrake step
-RIPMETHOD: "backup"
+RIPMETHOD: "mkv"
 
 # MakeMKV Arguments
 # MakeMKV Profile used for controlling Audio Track Selection.


### PR DESCRIPTION
# Description

Change RIPMETHOD from "backup" to "mkv".
I believe this will only affect new installs, my understanding is that users' customized arm.yaml should remain unaffected.

Workaround for:
docker Blu Ray fails #567

According to shitwolfymakes there is separate effort to update truth tables, which hopefully will include permanent fix.

Fixes #567 (docker Blu Ray fails)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
I changed my arm.yaml config accordingly, then Blu Ray rip succeeded

Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [X] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
