### PR TITLE
dev branch now properly checked out during clone

### DIFF
--- a/scripts/installers/ubuntu-20.04-install.sh
+++ b/scripts/installers/ubuntu-20.04-install.sh
@@ -119,7 +119,7 @@ function clone_arm() {
     fi
 
     if [ "$dev_env_flag" ]; then
-        git clone --recurse-submodules https://github.com/automatic-ripping-machine/automatic-ripping-machine arm
+        git clone --recurse-submodules https://github.com/automatic-ripping-machine/automatic-ripping-machine --branch "v2_devel" arm
     else
         ARM_LATEST=$(curl --silent 'https://github.com/automatic-ripping-machine/automatic-ripping-machine/releases' | grep 'automatic-ripping-machine/tree/*' | head -n 1 | sed -e 's/[^0-9\.]*//g')
         echo -e "Arm latest stable version is v$ARM_LATEST. Pulling v$ARM_LATEST"


### PR DESCRIPTION
# Description
This PR fixes a bug wherein the `v2_devel` branch was not being checked out when the installer was run with the `-d` flag to install the ARM Development Stack

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
