### PR TITLE
Fix publish-image workflow repo-agnosticism

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -117,4 +117,4 @@ jobs:
                     # make sure the github name is correct
                     dst: |
                          ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-                         ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
+                    #    ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -77,6 +77,7 @@ jobs:
                 uses: docker/metadata-action@69f6fc9d46f2f8bf0d5491e4aabe0bb8c6a4678a
                 with:
                     images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+                    
             -
                 name: Set Version number
                 run: |
@@ -93,6 +94,7 @@ jobs:
                 run: |
                     TIMESTAMP=$(date -u +'%Y-%m-%d T%H:%M:%SZ')
                     echo "BUILD_DATE=$TIMESTAMP" >> $GITHUB_ENV
+            
             # Build and push Docker image with Buildx
             # https://github.com/docker/build-push-action
             -
@@ -106,17 +108,4 @@ jobs:
                     tags: |
                       ${{ env.IMAGE_NAME }}:${{ env.TAG }}
                       ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-                    #  ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-                    #  ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
                     labels: ${{ steps.meta.outputs.labels }}
-
-            #-
-            #    name: retag and push multiplatform images to multiple registries
-            #    if: github.event_name != 'pull_request'
-            #    uses: akhilerm/tag-push-action@v2.0.0
-            #    with:
-            #        src: docker.io/${{ env.IMAGE_NAME }}:${{ env.TAG }}
-            #        # make sure the github name is correct
-            #        dst: |
-            #             ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-            #             ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -106,15 +106,17 @@ jobs:
                     tags: |
                       ${{ env.IMAGE_NAME }}:${{ env.TAG }}
                       ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
+                      ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
+                      ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
                     labels: ${{ steps.meta.outputs.labels }}
 
-            -
-                name: retag and push multiplatform images to multiple registries
-                if: github.event_name != 'pull_request'
-                uses: akhilerm/tag-push-action@v2.0.0
-                with:
-                    src: docker.io/${{ env.IMAGE_NAME }}:${{ env.TAG }}
-                    # make sure the github name is correct
-                    dst: |
-                         ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-                         ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
+            #-
+            #    name: retag and push multiplatform images to multiple registries
+            #    if: github.event_name != 'pull_request'
+            #    uses: akhilerm/tag-push-action@v2.0.0
+            #    with:
+            #        src: docker.io/${{ env.IMAGE_NAME }}:${{ env.TAG }}
+            #        # make sure the github name is correct
+            #        dst: |
+            #             ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
+            #             ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -117,4 +117,4 @@ jobs:
                     # make sure the github name is correct
                     dst: |
                          ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-                    #    ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
+                         ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -106,8 +106,8 @@ jobs:
                     tags: |
                       ${{ env.IMAGE_NAME }}:${{ env.TAG }}
                       ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-                      ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
-                      ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
+                    #  ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.TAG }}
+                    #  ${{ env.REGISTRY }}/${{ github.repository_owner }}/automatic-ripping-machine:${{ env.VERSION }}
                     labels: ${{ steps.meta.outputs.labels }}
 
             #-


### PR DESCRIPTION
# Description
Forking results in errors in the `publish-image` workflow even after populating the appropriate secrets.

This PR solves that issue by limiting images to being published on DockerHub only, while preserving the multi-architecture support that has been added.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
