### PR TITLE
Fixed bug with abcde config not updating

### DIFF
--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -15,7 +15,15 @@ def _load_config(fp):
     return config
 
 
+def load_abcde(fp):
+    with open(abcde_config_path, "r") as abcde_read_file:
+        config = abcde_read_file.read()
+    return config
+
+
+# aprise config, open and read yaml contents
 apprise_config = _load_config(apprise_config_path)
+# arm config, open and read yaml contents
 arm_config = _load_config(arm_config_path)
-with open(abcde_config_path, "r") as abcde_read_file:
-    abcde_config = abcde_read_file.read()
+# abcde config file, open and read contents
+abcde_config = load_abcde(abcde_config_path)

--- a/arm/config/config.py
+++ b/arm/config/config.py
@@ -16,7 +16,7 @@ def _load_config(fp):
 
 
 def load_abcde(fp):
-    with open(abcde_config_path, "r") as abcde_read_file:
+    with open(fp, "r") as abcde_read_file:
         config = abcde_read_file.read()
     return config
 

--- a/arm/ui/routes.py
+++ b/arm/ui/routes.py
@@ -385,6 +385,8 @@ def save_abcde():
             abcde_file.write(abcde_cfg_str)
             abcde_file.close()
         success = True
+        # Update the abcde config
+        cfg.abcde_config = abcde_cfg_str
     # If we get to here there was no post data
     return {'success': success, 'settings': abcde_cfg_str, 'form': 'abcde config'}
 


### PR DESCRIPTION
# Description

Fixes an issue where from the settings page changes to the abcde config update the file, but on page refresh are not displayed to the user. Updated to resolve.

Fixes - nil

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

minor bug fix, tested on armui, ubuntu 20.04

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
 _not required_
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
