### PR TITLE
2.6.9 Hotfixes

### DIFF
--- a/scripts/installers/ubuntu-20.04-install.sh
+++ b/scripts/installers/ubuntu-20.04-install.sh
@@ -98,6 +98,9 @@ function install_arm_requirements() {
         libdvd-pkg lsdvd
 
     sudo dpkg-reconfigure libdvd-pkg
+    
+    # create folders required to run the ARM service
+    sudo -u arm mkdir -p /home/arm/logs
 }
 
 function remove_existing_arm() {

--- a/scripts/installers/ubuntu-20.04-install.sh
+++ b/scripts/installers/ubuntu-20.04-install.sh
@@ -185,6 +185,8 @@ function setup_config_files() {
     # abcde.conf is expected in /etc by the abcde installation
     cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/.abcde.conf"
     chown arm:arm "/etc/.abcde.conf"
+    # link to the new install location so runui.py doesn't break
+    sudo -u arm ln -sf /etc/.abdce.conf /etc/arm/config/abcde.conf 
 
     if [[ $port_flag ]]; then
         echo -e "${RED}Non-default port specified, updating arm config...${NC}"


### PR DESCRIPTION
# Description
Fixes for breakages in the ubuntu installer script. This should be merged ASAP to prevent users from using the broken installer

This PR patches the following issues:
- #654  
- Fixes launch crash loop caused by the new copy destination of abcde.conf  

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [X] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
