### PR TITLE
ARM Installer bug fix

### DIFF
--- a/arm/ui/serverutil.py
+++ b/arm/ui/serverutil.py
@@ -69,5 +69,6 @@ class ServerUtil():
             disk_space = 0
             disk_percent = 0
             app.logger.debug("ARM folders not found")
-            flash(f"There was a problem accessing the ARM folder: '{filepath}'. Please make sure you have setup ARM", "danger")
+            flash("There was a problem accessing the ARM folder: "
+                  f"'{filepath}'. Please make sure you have setup ARM", "danger")
         return disk_space, disk_percent

--- a/arm/ui/serverutil.py
+++ b/arm/ui/serverutil.py
@@ -69,7 +69,5 @@ class ServerUtil():
             disk_space = 0
             disk_percent = 0
             app.logger.debug("ARM folders not found")
-            flash("There was a problem accessing the ARM folders. Please make sure you have setup ARM<br/>"
-                  "Setup can be started by visiting <a href=\"/setup\">setup page</a> ARM will not work correctly until"
-                  "you have added an admin account", "danger")
+            flash(f"There was a problem accessing the ARM folder: "{filepath}". Please make sure you have setup ARM", "danger")
         return disk_space, disk_percent

--- a/arm/ui/serverutil.py
+++ b/arm/ui/serverutil.py
@@ -69,5 +69,5 @@ class ServerUtil():
             disk_space = 0
             disk_percent = 0
             app.logger.debug("ARM folders not found")
-            flash(f"There was a problem accessing the ARM folder: "{filepath}". Please make sure you have setup ARM", "danger")
+            flash(f"There was a problem accessing the ARM folder: '{filepath}'. Please make sure you have setup ARM", "danger")
         return disk_space, disk_percent

--- a/scripts/installers/ubuntu-20.04-install.sh
+++ b/scripts/installers/ubuntu-20.04-install.sh
@@ -204,8 +204,8 @@ function install_python_requirements {
     echo -e "${RED}Installing up python requirements${NC}"
     cd /opt/arm
     # running pip with sudo can result in permissions errors, run as arm
-    sudo -u arm pip3 install --upgrade pip wheel setuptools psutil pyudev
-    sudo -u arm pip3 install --ignore-installed --prefer-binary -r requirements.txt
+    su - arm -c "pip3 install --upgrade pip wheel setuptools psutil pyudev"
+    su - arm -c "pip3 install --ignore-installed --prefer-binary -r /opt/arm/requirements.txt"
 }
 
 function setup_autoplay() {
@@ -259,6 +259,17 @@ function launch_setup() {
     fi
 }
 
+function create_folders() {
+    echo -e "${RED}Creating ARM folders${NC}"
+    arm_mkdir "/home/arm/media/transcode"
+    arm_mkdir "/home/arm/media/completed"
+}
+
+function arm_mkdir() {
+    echo -e "Creating $1"
+    su - arm -c "mkdir -p -v $1"
+}
+
 # start here
 install_os_tools
 add_arm_user
@@ -276,6 +287,7 @@ install_python_requirements
 setup_autoplay
 setup_syslog_rule
 install_armui_service
+create_folders
 launch_setup
 
 #advise to reboot


### PR DESCRIPTION
# Description
Resolved issues noted with the arm installer.
1. Failed python package install when using "sudo -u arm ...", changed to 'su - arm -c ..."
2. Install script doesn't create some directories, so the armui throws an error at the user on startup. Script updated to include those directories.
3. Updated the systeminfo flash message to include the missing directory, previous notification to the user was not helpful for the user to resolve.

Fixes #666 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ran on two new virtual images of Ubuntu 20.04.05, ran the install script multiple times and no issues noted with the update.

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have tested that my fix is effective or that my feature works
