### PR TITLE
Fix Docker breakages caused by 2.6.9+

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###########################################################
 # setup default directories and configs
-FROM automaticrippingmachine/arm-dependencies:1.0.4 AS base
+FROM automaticrippingmachine/arm-dependencies:1.0.5 AS base
 
 # override at runtime to change makemkv key
 ENV MAKEMKV_APP_KEY=""

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -56,12 +56,11 @@ done
         fi
     done
     chown -R arm:arm /etc/arm/
-    if [[ ! -f "/etc/arm/config/abcde.conf" ]] ; then
-        # abcde.conf is expected in /etc by the abcde installation
-        cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/arm/config/abcde.conf"
-        ln -s /etc/arm/config/abcde.conf /etc/.abcde.conf
-        chown arm:arm "/etc/arm/config/abcde.conf"
-    fi
+    
+    # abcde.conf is expected in /etc by the abcde installation
+    cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/.abcde.conf"
+    chown arm:arm "/etc/.abcde.conf"
+    sudo -u arm ln -sf /etc/.abcde.conf /etc/arm/config/abcde.conf
 
 echo "setting makemkv app-Key"
 if ! [[ -z "${MAKEMKV_APP_KEY}" ]] ; then


### PR DESCRIPTION
# Description
This PR fixes a bug and bumps `arm-dependencies` to 1.0.5 (Once 1.0.5 is released)

Fixes # (issue title here)
- #668 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested build of docker container from Dockerfile until successful, then ran a test rip.
[POINT_BREAK.log](https://github.com/automatic-ripping-machine/automatic-ripping-machine/files/10441984/POINT_BREAK.log)

- [x] Docker

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
