### PR TITLE
Bug Fix for Sensor Info in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ###########################################################
 # setup default directories and configs
-FROM automaticrippingmachine/arm-dependencies:1.0.4 AS base
+FROM automaticrippingmachine/arm-dependencies:1.0.5 AS base
 
 # override at runtime to change makemkv key
 ENV MAKEMKV_APP_KEY=""

--- a/arm/ui/serverutil.py
+++ b/arm/ui/serverutil.py
@@ -41,8 +41,8 @@ class ServerUtil():
     def get_cpu_temp(self):
         try:
             temps = psutil.sensors_temperatures()
-            if not len(temps) == 0:
-                self.cpu_temp = temps['coretemp'][0][1]
+            if coretemp := temps.get('coretemp', None):
+                self.cpu_temp = coretemp[0][1]
             else:
                 self.cpu_temp = 0
         except EnvironmentError:

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -56,12 +56,11 @@ done
         fi
     done
     chown -R arm:arm /etc/arm/
-    if [[ ! -f "/etc/arm/config/abcde.conf" ]] ; then
-        # abcde.conf is expected in /etc by the abcde installation
-        cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/arm/config/abcde.conf"
-        ln -s /etc/arm/config/abcde.conf /etc/.abcde.conf
-        chown arm:arm "/etc/arm/config/abcde.conf"
-    fi
+    
+    # abcde.conf is expected in /etc by the abcde installation
+    cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/.abcde.conf"
+    chown arm:arm "/etc/.abcde.conf"
+    sudo -u arm ln -sf /etc/.abcde.conf /etc/arm/config/abcde.conf
 
 echo "setting makemkv app-Key"
 if ! [[ -z "${MAKEMKV_APP_KEY}" ]] ; then


### PR DESCRIPTION
# Description

Fixes an issue in docker and probably some systems that don't report a coretemp for the CPU temperature, the index and settings page throw an error.

Fixes #665 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
