### PR TITLE
Allow Docker to shift load among a set number of CPUs 

### DIFF
--- a/scripts/docker/start_arm_container.sh
+++ b/scripts/docker/start_arm_container.sh
@@ -15,5 +15,5 @@ docker run -d \
     --privileged \
     --restart "always" \
     --name "arm-rippers" \
-    --cpus="6.5" \
+    --cpus="3" \
     IMAGE_NAME

--- a/scripts/docker/start_arm_container.sh
+++ b/scripts/docker/start_arm_container.sh
@@ -15,5 +15,5 @@ docker run -d \
     --privileged \
     --restart "always" \
     --name "arm-rippers" \
-    --cpuset-cpus='2,3,4,5,6,7...' \
+    --cpus="6.5" \
     IMAGE_NAME


### PR DESCRIPTION
... instead of assigning specific CPUs.

Ref: https://docs.docker.com/config/containers/resource_constraints/#cpu

If approved, need to update Wiki:
    https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/docker

# Description

Update to start_arm_container.sh. This change allows for cpu selection to be managed by Docker, which helps with performance tuning. 

Fixes # (issue title here)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [X] Docker
- [ ] Other (Please state here)

To change setting at startup, change the following in start_arm_container.sh:
    --cpus="6.5" \

To change setting during runtime use:
    docker container update [CONTAINER ID] --cpus="8"

# Checklist:

- [ ] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works
