### PR TITLE
Increase duplicate run detection to 3 minutes

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -768,7 +768,7 @@ def clean_for_filename(string):
 
 def duplicate_run_check(dev_path):
     """
-    This will kill any runs that have been triggered twice on the same device\n
+    Kills this run if another run was triggered recently on the same device\n
     Some drives will trigger the udev twice causing 1 disc insert to add 2 jobs\n
     this stops that issue
     :return: None
@@ -779,7 +779,9 @@ def duplicate_run_check(dev_path):
         for j in running_jobs:
             print(j.start_time - datetime.datetime.now())
             mins_last_run = int(round(abs(j.start_time - datetime.datetime.now()).total_seconds()) / 60)
-            if mins_last_run <= 1:
+            # Some (older) devices can take at least 3 minutes to receive the
+            # duplicate event, treat two events within 3 minutes as duplicate.
+            if mins_last_run <= 3:
                 logging.error(f"Job already running on {dev_path}")
                 sys.exit(1)
 


### PR DESCRIPTION
 * This is a hacky workaround to handle older hardware which will send duplicate udev events over 2 minutes after the initial drive event.

Fixes automatic-ripping-machine/automatic-ripping-machine#678

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [ ] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
