### PR TITLE
Key Update hotfix

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -34,7 +34,7 @@ def makemkv(logfile, job):
     """
 
     # confirm MKV is working, beta key hasn't expired
-    prep_mkv(job)
+    prep_mkv()
     logging.info(f"Starting MakeMKV rip. Method is {cfg['RIPMETHOD']}")
     # get MakeMKV disc number
     logging.debug("Getting MakeMKV disc number")
@@ -147,7 +147,7 @@ def setup_rawpath(job, rawpath):
     return rawpath
 
 
-def prep_mkv(job):
+def prep_mkv():
     """Make sure the MakeMKV key is up-to-date
 
     Parameters:

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -153,39 +153,9 @@ def prep_mkv(job):
     Parameters:
         job: job object\n
     Raises:
-        MakeMkvRuntimeException
-    """
-    logging.info("Prepping MakeMkv for usage...")
-
-    cmd = f"makemkvcon info {job.devpath}"
-    try:
-        # check=True is needed to make the exception throw on a non-zero return
-        subprocess.run(cmd, capture_output=True, shell=True, check=True)  # noqa: F841
-    except subprocess.CalledProcessError as mkv_error:
-        if mkv_error.returncode == 253:
-            # MakeMKV is out of date
-            logging.info("MakeMKV: return code is 253, MakeMKV beta key has expired.")
-            update_key()
-            try:
-                subprocess.run(cmd, capture_output=True, shell=True, check=True)  # noqa: F841
-            except subprocess.CalledProcessError as mkv_redux_error:
-                if mkv_redux_error.returncode == 10:
-                    logging.info("MakeMKV beta key updated successfully!")
-                else:
-                    raise MakeMkvRuntimeError(mkv_redux_error)
-        elif mkv_error.returncode == 10:
-            # For some fucking reason the nominal return value for `makemkvcon info` is 10
-            logging.info("MakeMKV is working as expected!")
-        else:
-            raise MakeMkvRuntimeError(mkv_error)
-
-
-def update_key():
-    """Run a script to update the MakeMKV beta key after it expires.
-
-    Raises:
         RuntimeError
     """
+    
     try:
         logging.info("Updating MakeMKV key...")
         update_cmd = "/bin/bash /opt/arm/scripts/update_key.sh"

--- a/scripts/update_key.sh
+++ b/scripts/update_key.sh
@@ -9,5 +9,6 @@
 makemkv_serial_url="https://forum.makemkv.com/forum/viewtopic.php?f=5&t=1053"
 makemkv_serial=$(curl -fsSL "$makemkv_serial_url" | grep -oP 'T-[\w\d@]{66}')
 echo "MakeMKV beta key for this month: $makemkv_serial"
-
+mkdir -p "/home/arm/.MakeMKV"
+chown arm:arm "/home/arm/.MakeMKV"
 echo "app_Key = \"$makemkv_serial\"" > /home/arm/.MakeMKV/settings.conf


### PR DESCRIPTION
# Description

Changes the logic to run `scripts/update_key.py` before every run, rather than trying to check MakeMKV's bizarre and inconsistent return codes to check if it's necessary.

NOTE: This change results in the MakeMKV settings file being overwritten every time. This is expected behaviour.

Fixes:
- #692
- A failure to write the key to file if the `.MakeMKV` folder doesn't already exist

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
