### PR TITLE
Fixes #625 - arm using HandBrake for Blurays

### DIFF
--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -183,7 +183,7 @@ def rip_with_mkv(current_job, protection=0):
     """
     mkv_ripped = False
     # Rip bluray
-    if current_job.disctype == "bluray" and current_job.config.RIPMETHOD == "mkv":
+    if current_job.disctype == "bluray":
         mkv_ripped = True
     # Rip dvd with mode: mkv and mainfeature: false
     if current_job.disctype == "dvd" and (not current_job.config.MAINFEATURE and current_job.config.RIPMETHOD == "mkv"):


### PR DESCRIPTION
Always force MakeMKV for bluray

# Description

ARM currently doesn't account for blurays needing to use the backup feature in MakeMKV, this solves the issues by forcing MakeMKV to be used for all blurays (It should always be used anyway)

Fixes #625

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
