### PR TITLE
Add transcode folder

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -34,7 +34,7 @@ fi
 chown -R arm:arm /opt/arm
 
 # setup needed/expected dirs if not found
-SUBDIRS="media media/completed media/raw media/movies logs db Music .MakeMKV"
+SUBDIRS="media media/completed media/raw media/movies media/transcode logs db Music .MakeMKV"
 for dir in $SUBDIRS ; do
     thisDir="$ARM_HOME/$dir"
     if [[ ! -d "$thisDir" ]] ; then


### PR DESCRIPTION
# Description

Add transcode folder to docker run, this stop the docker image from breaking when a disc is inserted on a fresh install.

Fixes #730

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
