### PR TITLE
Remove warning for NVME drives

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -301,7 +301,7 @@ def get_cdrom_status(devpath):
         disc_check = os.open(devpath, os.O_RDONLY | os.O_NONBLOCK)
     except OSError:
         # Sometimes ARM will log errors opening hard drives. this check should stop it
-        if not re.search(r'hd[a-j]|sd[a-j]|loop\d', devpath):
+        if not re.search(r'hd[a-j]|sd[a-j]|loop\d|nvme\d', devpath):
             logging.info(f"Failed to open device {devpath} to check status.")
         sys.exit(2)
     result = fcntl.ioctl(disc_check, 0x5326, 0)


### PR DESCRIPTION
# Description

ARM currently warns when ever udev can't open any NVME drives.
PR removes this warning as it can lead to confusion

Fixes #710

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [ ] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
