### PR TITLE
Fixes #741 - poster image not used from api

### DIFF
--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -130,6 +130,8 @@ def identify_dvd(job):
                 'imdb_id_auto': arm_api_json['results']['0']['imdb_id'],
                 'video_type': arm_api_json['results']['0']['video_type'],
                 'video_type_auto': arm_api_json['results']['0']['video_type'],
+                'poster_url': arm_api_json['results']['0']['poster_img'],
+                'poster_url_auto': arm_api_json['results']['0']['poster_img'],
                 'hasnicetitle': True
             }
             utils.database_updater(args, job)


### PR DESCRIPTION
# Description

The adds the poster image to the local database from the arm api

Fixes #741

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
