### PR TITLE
Add arm to the render group

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -29,6 +29,8 @@ elif [[ $ARM_UID -eq $DEFAULT_GID ]]; then
     echo -e "Updating arm group id $ARM_GID to default (1000)..."
     groupmod -og $DEFAULT_GID arm
 fi
+echo "Adding arm user to 'render' group"
+usermod -a -G render arm
 
 ### Setup Files
 chown -R arm:arm /opt/arm


### PR DESCRIPTION
# Description

This will add the arm user to the render group. This is required for Hardware encoding to work.

Fixes # N/A

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Ubuntu 18.04
- [x] Ubuntu 20.04
- [ ] Debian 10
- [ ] Debian 11
- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] **I have submitted this PR against the `v2_devel` branch (Unless the main branch has a security issue)**
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
