### PR TITLE
Handle abcde config changes on non-Linux machines

### DIFF
--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -164,15 +164,17 @@ def save_abcde():
     if form.validate():
         app.logger.debug(f"routes.save_abcde: Saving new abcde.conf: {cfg.abcde_config_path}")
         abcde_cfg_str = str(form.abcdeConfig.data).strip()
+        # Windows machines can put \r\n instead of \n newlines, which corrupts the config file
+        clean_abcde_str = '\n'.join(abcde_cfg_str.splitlines())
         # Save updated abcde.conf
         with open(cfg.abcde_config_path, "w") as abcde_file:
-            abcde_file.write(abcde_cfg_str)
+            abcde_file.write(clean_abcde_str)
             abcde_file.close()
         success = True
         # Update the abcde config
-        cfg.abcde_config = abcde_cfg_str
+        cfg.abcde_config = clean_abcde_str
     # If we get to here there was no post data
-    return {'success': success, 'settings': abcde_cfg_str, 'form': 'abcde config'}
+    return {'success': success, 'settings': clean_abcde_str, 'form': 'abcde config'}
 
 
 @route_settings.route('/save_apprise_cfg', methods=['POST'])


### PR DESCRIPTION
# Description
I found that when trying to update abcde configuration from a windows machine, the config file ended up corrupted with \r\n line endings. This change ensures that the line endings are correct for linux.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [x] Other (Please state here) Deployed locally to test

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [n/a] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Clean the contents of abcde config before saving.

# Logs
Attach logs from successful test runs here
