### PR TITLE
Added the missing 5th drive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ EXPOSE 8080
 # Setup folders and fstab
 RUN \
     mkdir -m 0777 -p /home/arm \
-    /home/arm/config \
-    /mnt/dev/sr0 /mnt/dev/sr1 /mnt/dev/sr2 /mnt/dev/sr3 \
+    /home/arm/config /mnt/dev/sr0 \
+    /mnt/dev/sr1 /mnt/dev/sr2 /mnt/dev/sr3 /mnt/dev/sr4 \
     /mnt/dev/sr5 /mnt/dev/sr6 /mnt/dev/sr7 /mnt/dev/sr8 \
     /mnt/dev/sr9 /mnt/dev/sr10 /mnt/dev/sr11 /mnt/dev/sr12 \
     /mnt/dev/sr13 /mnt/dev/sr14 /mnt/dev/sr15 /mnt/dev/sr16 \


### PR DESCRIPTION
# Description
When a fifth drive was added, the disc was immediately rejected.  
I checked the code and saw that drive sr4 was missing.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Added the misssing 5th drive. 

# Logs
