### PR TITLE
Change default music container path in start_arm_container.sh from /Music to /music

### DIFF
--- a/scripts/docker/start_arm_container.sh
+++ b/scripts/docker/start_arm_container.sh
@@ -4,7 +4,7 @@ docker run -d \
     -e ARM_UID="<id -u arm>" \
     -e ARM_GID="<id -g arm>" \
     -v "<path_to_arm_user_home_folder>:/home/arm" \
-    -v "<path_to_music_folder>:/home/arm/Music" \
+    -v "<path_to_music_folder>:/home/arm/music" \
     -v "<path_to_logs_folder>:/home/arm/logs" \
     -v "<path_to_media_folder>:/home/arm/media" \
     -v "<path_to_config_folder>:/etc/arm/config" \


### PR DESCRIPTION
# Description
In the default configuration, ARM writes music to the music folder, not Music folder. This becomes a problem if you mount /home/arm and /home/arm/Music to different locations. 
Changing the container path in the start_arm_container.sh to music solves this issue.

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Start docker with new start_arm_container container_path with different host paths for /home/arm and /home/arm/music. Using Music as container path, cd output will not be shown in host path. With music as container path, cd output is shown in host path

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Changed default music container path in start_arm_container.sh from /home/arm/Music to /home/arm/music

# Logs
Attach logs from successful test runs here
