### PR TITLE
Ntfy and Bash for notifications

### DIFF
--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -136,7 +136,7 @@ def apprise_notify(apprise_cfg, title, body):
                 body,
                 title=title,
             )
-            logging.debug(f"Sent apprise to ntfy was successful")
+            logging.debug("Sent apprise to ntfy was successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending ntfy apprise notification.  continuing  processing...{error}")
 
@@ -144,6 +144,6 @@ def apprise_notify(apprise_cfg, title, body):
     if cfg['BASH_SCRIPT'] != "":
         try:
             subprocess.run([cfg['BASH_SCRIPT'], title, body])
-            logging.debug(f"Sent bash notification successful")
+            logging.debug("Sent bash notification successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending notification via bash.  continuing  processing...{error}")

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -102,6 +102,7 @@ def apprise_notify(apprise_cfg, title, body):
 
     ntfy_notify(cfg, title, body)
 
+
 def ntfy_notify(cfg, title, body):
     # ntfy can require additional processing to make https work. In addition, there are multiple available valid schemes.
     if cfg['NTFY_TOPIC'] != "":
@@ -144,6 +145,7 @@ def ntfy_notify(cfg, title, body):
             logging.debug("Sent apprise to ntfy was successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending ntfy apprise notification.  continuing  processing...{error}")
+
 
 def bash_notify(cfg, title, body):
     # bash notifications use subprocess instead of apprise.

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -104,7 +104,8 @@ def apprise_notify(apprise_cfg, title, body):
 
 
 def ntfy_notify(cfg, title, body):
-    # ntfy can require additional processing to make https work. In addition, there are multiple available valid schemes.
+    # ntfy can require additional processing to make https work.
+    # In addition, there are multiple available valid schemes.
     if cfg['NTFY_TOPIC'] != "":
         try:
             apobj = apprise.Apprise()
@@ -144,7 +145,7 @@ def ntfy_notify(cfg, title, body):
             )
             logging.debug("Sent apprise to ntfy was successful")
         except Exception as error:  # noqa: E722
-            logging.error(f"Failed sending ntfy apprise notification.  continuing  processing...{error}")
+            logging.error(f"Failed sending ntfy apprise notification. Continuing  processing...{error}")
 
 
 def bash_notify(cfg, title, body):
@@ -154,4 +155,4 @@ def bash_notify(cfg, title, body):
             subprocess.run([cfg['BASH_SCRIPT'], title, body])
             logging.debug("Sent bash notification successful")
         except Exception as error:  # noqa: E722
-            logging.error(f"Failed sending notification via bash.  continuing  processing...{error}")
+            logging.error(f"Failed sending notification via bash. Continuing  processing...{error}")

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -2,6 +2,7 @@
 import logging
 import yaml
 import apprise
+import subprocess
 
 
 # TODO: Refactor this to leverage apprise_config stored in config.py
@@ -96,3 +97,53 @@ def apprise_notify(apprise_cfg, title, body):
                 logging.debug(f"Sent apprise to {host} was successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending {host} apprise notification.  continuing  processing...{error}")
+
+    # ntfy can require additional processing to make https work. Also there are multiple available valid schemes.
+    if cfg['NTFY_TOPIC'] != "":
+        try:
+            apobj = apprise.Apprise()
+            ntfy_serverstring = 'ntfy://'
+
+            host = cfg['NTFY_URL']
+
+            if host.startswith("https://"):
+                ntfy_serverstring = 'ntfys://'
+                host = host.replace("https://", "")
+
+            if host.startswith("http://"):
+                host = host.replace("http://", "")
+
+            if cfg['NTFY_USER'] != "" and cfg['NTFY_PASS'] != "" and host != "":
+                ntfy_serverstring += cfg['NTFY_USER'] + ':' + cfg['NTFY_PASS'] + '@' + host
+
+            elif cfg['NTFY_USER'] != "" and host != "":
+                ntfy_serverstring += cfg['NTFY_USER'] + '@' + host
+
+            elif host != "":
+                ntfy_serverstring += host
+
+            if host != "" and cfg['NTFY_PORT'] != "":
+                ntfy_serverstring += ':' + cfg['NTFY_PORT'] + '/'
+            else:
+                if ntfy_serverstring != 'ntfy://':
+                    ntfy_serverstring += '/'
+
+            ntfy_serverstring += cfg['NTFY_TOPIC']
+
+            print(ntfy_serverstring)
+            apobj.add(ntfy_serverstring)
+            apobj.notify(
+                body,
+                title=title,
+            )
+            logging.debug(f"Sent apprise to ntfy was successful")
+        except Exception as error:  # noqa: E722
+            logging.error(f"Failed sending ntfy apprise notification.  continuing  processing...{error}")
+
+    # bash notifications use subprocess instead of apprise.
+    if cfg['BASH_SCRIPT'] != "":
+        try:
+            subprocess.run([cfg['BASH_SCRIPT'], title, body])
+            logging.debug(f"Sent bash notification successful")
+        except Exception as error:  # noqa: E722
+            logging.error(f"Failed sending notification via bash.  continuing  processing...{error}")

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -85,8 +85,6 @@ def apprise_notify(apprise_cfg, title, body):
     with open(apprise_cfg, "r") as yaml_file:
         cfg = yaml.safe_load(yaml_file)
 
-    bash_notify(cfg, title, body)
-
     sent_cfg = build_apprise_sent(cfg)
     for host, string in sent_cfg.items():
         try:
@@ -146,13 +144,3 @@ def ntfy_notify(cfg, title, body):
             logging.debug("Sent apprise to ntfy was successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending ntfy apprise notification. Continuing  processing...{error}")
-
-
-def bash_notify(cfg, title, body):
-    # bash notifications use subprocess instead of apprise.
-    if cfg['BASH_SCRIPT'] != "":
-        try:
-            subprocess.run([cfg['BASH_SCRIPT'], title, body])
-            logging.debug("Sent bash notification successful")
-        except Exception as error:  # noqa: E722
-            logging.error(f"Failed sending notification via bash. Continuing  processing...{error}")

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -85,6 +85,8 @@ def apprise_notify(apprise_cfg, title, body):
     with open(apprise_cfg, "r") as yaml_file:
         cfg = yaml.safe_load(yaml_file)
 
+    bash_notify(cfg, title, body)
+
     sent_cfg = build_apprise_sent(cfg)
     for host, string in sent_cfg.items():
         try:
@@ -98,7 +100,10 @@ def apprise_notify(apprise_cfg, title, body):
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending {host} apprise notification.  continuing  processing...{error}")
 
-    # ntfy can require additional processing to make https work. Also there are multiple available valid schemes.
+    ntfy_notify(cfg, title, body)
+
+def ntfy_notify(cfg, title, body):
+    # ntfy can require additional processing to make https work. In addition, there are multiple available valid schemes.
     if cfg['NTFY_TOPIC'] != "":
         try:
             apobj = apprise.Apprise()
@@ -140,6 +145,7 @@ def apprise_notify(apprise_cfg, title, body):
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending ntfy apprise notification.  continuing  processing...{error}")
 
+def bash_notify(cfg, title, body):
     # bash notifications use subprocess instead of apprise.
     if cfg['BASH_SCRIPT'] != "":
         try:

--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -2,7 +2,6 @@
 import logging
 import yaml
 import apprise
-import subprocess
 
 
 # TODO: Refactor this to leverage apprise_config stored in config.py

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -44,6 +44,8 @@ def notify(job, title, body):
     notification = models.Notifications(title, body)
     database_adder(notification)
 
+    bash_notify(cfg.arm_config, title, body)
+
     # Sent to remote sites
     # Create an Apprise instance
     apobj = apprise.Apprise()
@@ -66,6 +68,16 @@ def notify(job, title, body):
             logging.debug(f"apprise-config: {cfg.arm_config['APPRISE']}")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending apprise notifications. {error}")
+
+
+def bash_notify(cfg, title, body):
+    # bash notifications use subprocess instead of apprise.
+    if cfg['BASH_SCRIPT'] != "":
+        try:
+            subprocess.run(["/usr/bin/bash", cfg['BASH_SCRIPT'], title, body])
+            logging.debug("Sent bash notification successful")
+        except Exception as error:  # noqa: E722
+            logging.error(f"Failed sending notification via bash. Continuing  processing...{error}")
 
 
 def notify_entry(job):

--- a/devtools/README.md
+++ b/devtools/README.md
@@ -23,7 +23,7 @@ Currently a work in progress.
 ## Usage
 
 $python3 armdevtools.py -h
-usage: armdevtools.py [-h] [-b B] [-d] [-db_rem] [-db_roll DB_ROLL] [-db_data] [-v]
+usage: armdevtools.py [-h] [-b B] [-d] [-db_rem] [-db_roll DB_ROLL] [-db_data] [-v] [-n]
 
 Automatic Ripping Machine Development Tool Scripts
 
@@ -37,6 +37,7 @@ options:
                     be the most current
   -qa               QA Checks - run Flake8 against ARM
   -pr               Actions to run prior to commiting a PR against ARM on github
+  -pr               Run a testnotification
   -v                ARM Dev Tools Version
 
 

--- a/devtools/armdevtools.py
+++ b/devtools/armdevtools.py
@@ -16,6 +16,7 @@ import argparse
 import armgit
 import database
 import armdocker
+import armnotify
 
 
 __version__ = '0.2'
@@ -41,6 +42,9 @@ parser.add_argument("-qa",
 parser.add_argument("-pr",
                     help="Actions to run prior to committing a PR against ARM on github",
                     action="store_true")
+parser.add_argument("-n",
+                    help="Notification tool - show a test notification",
+                    action="store_true")
 parser.add_argument("-v", help="ARM Dev Tools Version",
                     action='version',
                     version='%(prog)s {version}'.format(version=__version__))
@@ -64,3 +68,6 @@ if args.qa:
 
 if args.pr:
     armgit.pr_update()
+
+if args.n:
+    armnotify.test()

--- a/devtools/armnotify.py
+++ b/devtools/armnotify.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+"""
+Automatic-Ripping-Machine Development Tools
+    ARM Notify test tools
+"""
+
+import os
+import log
+from arm.ripper import utils
+from arm.models.models import Job
+
+
+def test():
+    """
+    Run a notification
+        INPUT: none
+        OUTPUT: none
+    """
+    try:
+        job = Job("/dev/null")
+        utils.notify(job, "ARM notification", "This is a notification by the ARM-Notification Test!")
+    except Exception as error:
+        log.error(f"ARM Notify failed to run - {error}")

--- a/devtools/armnotify.py
+++ b/devtools/armnotify.py
@@ -6,7 +6,6 @@ Automatic-Ripping-Machine Development Tools
     ARM Notify test tools
 """
 
-import os
 import log
 from arm.ripper import utils
 from arm.models.models import Job

--- a/setup/apprise.yaml
+++ b/setup/apprise.yaml
@@ -5,6 +5,13 @@
 BOXCAR_KEY: ""
 BOXCAR_SECRET: ""
 
+## Specify a script to be called.
+# We will call the script with two arguments:
+# First Argument: Title
+# Second Argument: Body
+# This does not use apprise!
+BASH_SCRIPT: ""
+
 ## Discord bot
 ## Full info @ https://github.com/caronc/apprise/wiki/Notify_discord
 ## Leave DISCORD_WEBHOOK_ID blank to disable
@@ -96,6 +103,13 @@ NOTICA_TOKEN: ""
 
 NOTIFICO_PROJECTID: ""
 NOTIFICO_MESSAGEHOOK: ""
+
+## ntfy Notifications
+NTFY_TOPIC: ""
+NTFY_URL: ""   # Optional. Prepend http/https!
+NTFY_PORT: ""   # Optional. Must have URL!
+NTFY_USER: ""   # Optional.
+NTFY_PASS: ""   # Optional. Must have User!
 
 ## All of these are required || leave OFFICE365_TENANTID blank to disable
 OFFICE365_TENANTID: ""

--- a/setup/apprise.yaml
+++ b/setup/apprise.yaml
@@ -5,13 +5,6 @@
 BOXCAR_KEY: ""
 BOXCAR_SECRET: ""
 
-## Specify a script to be called.
-# We will call the script with two arguments:
-# First Argument: Title
-# Second Argument: Body
-# This does not use apprise!
-BASH_SCRIPT: ""
-
 ## Discord bot
 ## Full info @ https://github.com/caronc/apprise/wiki/Notify_discord
 ## Leave DISCORD_WEBHOOK_ID blank to disable

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -306,6 +306,14 @@ IFTTT_EVENT: "arm_event"
 PO_USER_KEY: ""
 PO_APP_KEY: ""
 
+
+## Specify a script to be called.
+# We will call the script with two arguments:
+# First Argument: Title
+# Second Argument: Body
+BASH_SCRIPT: ""
+
+
 # OMDB_API_KEY
 # omdbapi.com API Key
 # See README-OMDBAPI for background and info


### PR DESCRIPTION
# Description
This allows the user to use Ntfy.sh for notifications.
It also allows the user to use a generic bash script to be called for notifications allowing even more flexibility.
I included a tiny test-script that allows any developer to execute the notification stack without a full working arm-stack.

Fixes #924

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?
Via the provided Test-Script and my own test instance.

- [ ] Docker
- [x] Other (See above)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Add ntfy as a notification target
- Add bash as a notification target

# Logs
None