### PR TITLE
Add option to disable ejection on an unidentified disc (#779)

### DIFF
--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -31,6 +31,7 @@
   "METADATA_PROVIDER": "# This selects the metadata provider, Each provider has their own ups and downs\n# But a general rule would be \n# OMDB for movies and shows \n# TMDB for movies only\n# You will still need to provide an api key for the provider you have selected",
   "GET_AUDIO_TITLE": "# Set to one of \"none\", \"musicbrainz\", \"freecddb\"\n# if \"musicbrainz\" is used the disc information are asked from musicbrainz.org\n# if \"none\" is used no label is identified",
   "RIP_POSTER": "# Rip DVD Posters from JACKET_P folder\n# Requires FFmpeg",
+  "UNIDENTIFIED_EJECT": "# Auto-eject unidentified discs (blank etc)\n# May want to set this to false on certain (Pioneer slim) drives to prevent the immediate eject\n# issue (https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/779)",
   "ABCDE_CONFIG_FILE": "# Location of your ABCDE config file",
   "RAW_PATH": "# Path to raw MakeMKV directory\n# Destination for MakeMKV and source for HandBrake",
   "TRANSCODE_PATH": "# Intermediary directory for transcoding files\n# Destination for HandBrake",

--- a/scripts/docker/docker_arm_wrapper.sh
+++ b/scripts/docker/docker_arm_wrapper.sh
@@ -60,7 +60,9 @@ elif [ "$ID_FS_TYPE" != "" ]; then
 else
 	  echo "[ARM] Not CD, Blu-ray, DVD or Data. Bailing out on ${DEVNAME}" | logger -t ARM -s
 	  echo "$(date) [ARM] Not CD, Blu-ray, DVD or Data. Bailing out on ${DEVNAME}" >> $ARMLOG
-	  eject "${DEVNAME}"
+      if [ "$CONFIG_UNIDENTIFIED_EJECT" != "false" ]; then
+	    eject "${DEVNAME}"
+      fi
 	  exit #bail out
 fi
 cd /home/arm

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -102,6 +102,11 @@ GET_AUDIO_TITLE: "musicbrainz"
 # Requires FFmpeg
 RIP_POSTER: false
 
+# Auto-eject unidentified discs (blank etc)
+# May want to set this to false on certain (Pioneer slim) drives to prevent the immediate eject
+# issue (https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/779)
+UNIDENTIFIED_EJECT: true
+
 
 #####################
 ## Directory setup ##


### PR DESCRIPTION
# Description
Disables the automatic ejecting of an unidentified disc, to prevent immediate ejection of discs on certain (Pioneer slim) drives.

Fixes #779

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
(Could be seen as both)

# How Has This Been Tested?
Several people on the ticket including me have tested removing the offending line (including me).
I have added extra code to make this configurable, with the default behaviour being the original behaviour.

- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works