### PR TITLE
Fix handling of the abcde.conf file for docker

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -36,6 +36,7 @@ usermod -a -G render arm
 chown -R arm:arm /opt/arm
 
 # setup needed/expected dirs if not found
+chown arm:arm $ARM_HOME
 SUBDIRS="media media/completed media/raw media/movies media/transcode logs logs/progress db Music .MakeMKV"
 for dir in $SUBDIRS ; do
     thisDir="$ARM_HOME/$dir"
@@ -46,20 +47,23 @@ for dir in $SUBDIRS ; do
     chown -R arm:arm "$thisDir"
 done
 
-    ##### Setup ARM-specific config files if not found
-    mkdir -p /etc/arm/config
-    CONFS="arm.yaml apprise.yaml"
-    for conf in $CONFS; do
-        thisConf="/etc/arm/config/${conf}"
-        if [[ ! -f "${thisConf}" ]] ; then
-            echo "Config not found! Creating config file: ${thisConf}"
-            # Don't overwrite with defaults during reinstall
-            cp --no-clobber "/opt/arm/setup/${conf}" "${thisConf}"
-        fi
-    done
-    chown -R arm:arm /etc/arm/
-    
-    # abcde.conf is expected in /etc by the abcde installation
-    cp --no-clobber /opt/arm/setup/.abcde.conf /etc/arm/config/abcde.conf
-    ln -sf /etc/arm/config/abcde.conf /etc/.abcde.conf
-    chown arm:arm /etc/.abcde.conf /etc/arm/config/abcde.conf
+##### Setup ARM-specific config files if not found
+mkdir -p /etc/arm/config
+CONFS="arm.yaml apprise.yaml"
+for conf in $CONFS; do
+    thisConf="/etc/arm/config/${conf}"
+    if [[ ! -f "${thisConf}" ]] ; then
+        echo "Config not found! Creating config file: ${thisConf}"
+        # Don't overwrite with defaults during reinstall
+        cp --no-clobber "/opt/arm/setup/${conf}" "${thisConf}"
+    fi
+done
+chown -R arm:arm /etc/arm/
+
+# abcde.conf is expected in /etc by the abcde installation
+cp --no-clobber /opt/arm/setup/.abcde.conf /etc/arm/config/abcde.conf
+ln -sf /etc/arm/config/abcde.conf /etc/abcde.conf
+chown arm:arm /etc/abcde.conf /etc/arm/config/abcde.conf
+
+# symlink $ARM_HOME/Music to $ARM_HOME/music because the config for abcde doesn't match the docker compose docs
+ln -sf $ARM_HOME/Music $ARM_HOME/music

--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -60,6 +60,6 @@ done
     chown -R arm:arm /etc/arm/
     
     # abcde.conf is expected in /etc by the abcde installation
-    cp --no-clobber "/opt/arm/setup/.abcde.conf" "/etc/.abcde.conf"
-    ln -sf /etc/.abcde.conf /etc/arm/config/abcde.conf
-    chown arm:arm "/etc/.abcde.conf" "/etc/arm/config/abcde.conf"
+    cp --no-clobber /opt/arm/setup/.abcde.conf /etc/arm/config/abcde.conf
+    ln -sf /etc/arm/config/abcde.conf /etc/.abcde.conf
+    chown arm:arm /etc/.abcde.conf /etc/arm/config/abcde.conf


### PR DESCRIPTION
# Description
In docker the abcde.conf file from the config volume would be overwritten by a symlink to /etc/abcde.conf
This behaviour is incorrect, so has been fixed to symlink /etc/abcde.conf to the file in the config volume.

abcde seemed unable to create temp files etc in ~ directory so chown it to arm user

Default abcde.conf outputs to ~/music the docker compose docs and the code sets up ~/Music, so to ave screwing up anyones environments just symlink those together for now.

Fixes #749

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
(Technically breaking as it replaces any config set in the UI from before the change then again this would have been lost on an update anyway)

# How Has This Been Tested?
Built and tested the docker image with the changes.

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works