### PR TITLE
Add k10temp support for more AMD platforms

### DIFF
--- a/arm/ui/settings/ServerUtil.py
+++ b/arm/ui/settings/ServerUtil.py
@@ -62,6 +62,10 @@ class ServerUtil():
             elif cpu_thermal := temps.get('cpu_thermal', None):
                 self.cpu_temp = cpu_thermal[0][1]
 
+            # cpu temperature - AMD systems (generic)
+            elif k10temp := temps.get('k10temp', None):
+                self.cpu_temp = k10temp[0][1]
+
             # cpu temperature - unknown devices
             else:
                 self.cpu_temp = 0


### PR DESCRIPTION
# Description
An extension of #844, which was a fix for #754.

While adding the I/O expansion chips for the other platforms is useful, k10temp is a kernel driver that automatically handles getting temperature for AMD CPUs. In the event that the other I/O chip readings are preferred, I have placed this addition at the bottom of the list.

A list of platforms supported is here: https://docs.kernel.org/hwmon/k10temp.html

Generally, the kernel driver covers AMD Family 10h (Opteron, 2007-2012) through 19h (Zen 4, Sept 2022 - current).

Fixes #754

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- ServerUtil - Add reading k10temp for AMD Platform CPU Temperatures

# Logs
N/A
