### PR TITLE
Parse bluray label for OMDB search

### DIFF
--- a/arm/ripper/identify.py
+++ b/arm/ripper/identify.py
@@ -81,10 +81,20 @@ def identify_bluray(job):
                       "Disc cannot be identified.  Error "
                       f"number is: {error.errno}")
         # Maybe call OMdb with label when we can't find any ident on disc ?
-        job.title = str(job.label)
-        job.year = ""
-        db.session.commit()
-        return False
+        # Attempt to parse label
+        if str(job.label) == "":
+            job.title = str(job.label)
+            job.year = ""
+            db.session.commit()
+            return False
+        else:
+            bluray_title = str(job.label)
+            bluray_title = bluray_title.replace('_', ' ')
+            bluray_title = bluray_title.title()
+            job.title = job.title_auto = bluray_title
+            job.year = ""
+            db.session.commit()
+            return True
 
     try:
         bluray_title = doc['disclib']['di:discinfo']['di:title']['di:name']


### PR DESCRIPTION
# Description
In cases where the service cannot mount the drive (such as without privileged mode enabled) or bdmt_eng.xml is not present, this will use the udev detected label of the disk as a stand in title, formatted with title casing.

Fixes # (issue title here)
N/A

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] Docker

Ran the container without privileged mode as a test, and inserted various Blu-ray discs, including UHD.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Use Blu-ray disc label as title, and pass to OMDB lookup

# Logs

<details>
<summary> Log run from "The Social Network" BD</summary>

```
<snip>

[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ******************* Logging udev attributes *******************
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params DEVLINKS:/dev/disk/by-id/usb-BUFFALO_Optical_Drive_B2C0701783-0:0 /dev/disk/by-path/pci-0000:01:00.0-usb-0:2:1.0-scsi-0:0:0:0 /dev/dvdrw /dev/cdrw /dev/dvd /dev/cdrom /dev/disk/by-label/THE_SOCIAL_NETWORK /dev/disk/by-uuid/8cd5f71aa9d5b565
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params DEVNAME:/dev/sr0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params DEVPATH:/devices/pci0000:00/0000:00:01.3/0000:01:00.0/usb2/2-2/2-2:1.0/host15/target15:0:0/15:0:0:0/block/sr0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params DEVTYPE:disk
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params DISKSEQ:85
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_BUS:usb
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_BD:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_BD_R:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_BD_RE:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_CD:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_CD_R:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_CD_RW:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_PLUS_R:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_PLUS_RW:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_PLUS_R_DL:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_R:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_RAM:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_DVD_RW:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA_BD:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA_SESSION_COUNT:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA_STATE:complete
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA_TRACK_COUNT:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MEDIA_TRACK_COUNT_DATA:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MRW:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_CDROM_MRW_W:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FOR_SEAT:block-pci-0000_01_00_0-usb-0_2_1_0-scsi-0_0_0_0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_LABEL:THE_SOCIAL_NETWORK
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_LABEL_ENC:THE_SOCIAL_NETWORK
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_TYPE:udf
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_USAGE:filesystem
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_UUID:8cd5f71aa9d5b565
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_UUID_ENC:8cd5f71aa9d5b565
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_FS_VERSION:2.50
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_INSTANCE:0:0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_MODEL:Optical_Drive
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_MODEL_ENC:Optical\x20Drive\x20\x20\x20
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_MODEL_ID:0386
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_PATH:pci-0000:01:00.0-usb-0:2:1.0-scsi-0:0:0:0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_PATH_TAG:pci-0000_01_00_0-usb-0_2_1_0-scsi-0_0_0_0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_REVISION:0001
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_SERIAL:BUFFALO_Optical_Drive_B2C0701783-0:0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_SERIAL_SHORT:B2C0701783
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_TYPE:cd
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_USB_DRIVER:usb-storage
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_USB_INTERFACES::080650:
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_USB_INTERFACE_NUM:00
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_VENDOR:BUFFALO
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_VENDOR_ENC:BUFFALO\x20
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ID_VENDOR_ID:0411
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params MAJOR:11
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params MINOR:0
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params SUBSYSTEM:block
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params SYSTEMD_MOUNT_DEVICE_BOUND:1
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params TAGS::systemd:seat:uaccess:
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params USEC_INITIALIZED:3766868836681
[10-21-2023 19:23:14] DEBUG ARM: main.log_udev_params ******************* End udev attributes *******************
[10-21-2023 19:23:14] INFO ARM: main.main Starting Disc identification
[10-21-2023 19:23:14] DEBUG ARM: identify.identify Identify Entry point --- job ----
[10-21-2023 19:23:14] INFO ARM: identify.identify Mounting disc to: /mnt/dev/sr0
[10-21-2023 19:23:14] ERROR ARM: identify.check_if_mounted Mounting failed! Rip might have problems
[10-21-2023 19:23:14] INFO ARM: identify.identify Disc identified as video
[10-21-2023 19:23:14] ERROR ARM: identify.identify_bluray Disc is a bluray, but bdmt_eng.xml could not be found. Disc cannot be identified.  Error number is: 2
[10-21-2023 19:23:15] DEBUG ARM: identify.get_video_details Title = The Social Network
[10-21-2023 19:23:15] DEBUG ARM: identify.get_video_details Title: The+Social+Network | Year: 
[10-21-2023 19:23:15] DEBUG ARM: identify.get_video_details Calling webservice with title: The+Social+Network and year: 
[10-21-2023 19:23:15] DEBUG ARM: identify.identify_loop Response = None
[10-21-2023 19:23:15] DEBUG ARM: identify.try_without_year Removing year...
[10-21-2023 19:23:15] DEBUG ARM: identify.metadata_selector provider omdb
[10-21-2023 19:23:15] DEBUG ARM: metadata.call_omdb_api omdb - {'Search': [{'Title': 'The Social Network', 'Year': '2010', 'imdbID': 'tt1285016', 'Type': 'movie', 'Poster': 'https://m.media-amazon.com/images/M/MV5BOGUyZDUxZjEtMmIzMC00MzlmLTg4MGItZWJmMzBhZjE0Mjc1XkEyXkFqcGdeQXVyMTMxODk2OTU@._V1_SX300.jpg'}, {'Title': '#chicagoGirl: The Social Network Takes on a Dictator', 'Year': '2013', 'imdbID': 'tt2607968', 'Type': 'movie', 'Poster': 'https://m.media-amazon.com/images/M/MV5BMTgwODIxMjM3NV5BMl5BanBnXkFtZTgwMzYzODA2NjE@._V1_SX300.jpg'}, {'Title': 'The Social Network: T4 Movie Special', 'Year': '2010', 'imdbID': 'tt1743975', 'Type': 'movie', 'Poster': 'https://m.media-amazon.com/images/M/MV5BZDE0YjcxMTUtNzVmNy00Y2Y5LTkyNmUtY2VkMWEyN2U1YmZhXkEyXkFqcGdeQXVyNzQzNzQxNzI@._V1_SX300.jpg'}, {'Title': 'Murder on the Social Network', 'Year': '2011', 'imdbID': 'tt7066232', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network: David Fincher and Jeff Cronenweth on the Visuals', 'Year': '2011', 'imdbID': 'tt5452904', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network: Angus Wall, Kirk Baxter and Ren Klyce on Post', 'Year': '2011', 'imdbID': 'tt5452912', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network: Trent Reznor, Atticus Ross and David Fincher on the Score', 'Year': '2011', 'imdbID': 'tt5452914', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network: Swarmatron', 'Year': '2011', 'imdbID': 'tt5452928', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network: In the Hall of the Mountain King Music Exploration', 'Year': '2011', 'imdbID': 'tt5452934', 'Type': 'movie', 'Poster': 'N/A'}, {'Title': 'The Social Network Show', 'Year': '2013–2014', 'imdbID': 'tt15023424', 'Type': 'series', 'Poster': 'https://m.media-amazon.com/images/M/MV5BMGJiM2I0NzgtYzYyYy00NzA1LWE2MjYtYjk1OWIyNGRhNGIzXkEyXkFqcGdeQXVyMTI1NTQ4OTM4._V1_SX300.jpg'}], 'totalResults': '12', 'Response': 'True', 'background_url': None}
[10-21-2023 19:23:15] DEBUG ARM: metadata.call_omdb_api omdb - call was successful
[10-21-2023 19:23:15] DEBUG ARM: identify.update_job Webservice successful.  New title is The-Social-Network.  New Year is: 2010

<snip>

</details>