### PR TITLE
Add Apprise test button

### DIFF
--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -10,6 +10,7 @@ Covers
 - systemdrivescan [GET]
 - update_arm [POST]
 - drive_eject [GET]
+- testapprise [GET]
 """
 
 import os
@@ -30,6 +31,7 @@ import arm.config.config as cfg
 from arm.ui.settings import DriveUtils as drive_utils
 from arm.ui.forms import SettingsForm, UiSettingsForm, AbcdeForm, SystemInfoDrives
 from arm.ui.settings.ServerUtil import ServerUtil
+import arm.ripper.utils as ripper_utils
 
 route_settings = Blueprint('route_settings', __name__,
                            template_folder='templates',
@@ -297,4 +299,17 @@ def drive_eject(id):
     drive = models.SystemDrives.query.filter_by(drive_id=id).first()
     drive.open_close()
     db.session.commit()
+    return redirect(redirect_settings)
+
+@route_settings.route('/testapprise')
+def testapprise():
+    """
+    Page - testapprise
+    Method - GET
+    Overview - Send a test notification to Apprise.
+    """
+    global redirect_settings
+    # Send a sample notification
+    ripper_utils.notify("/dev/null", "ARM notification", "This is a notification by the ARM-Notification Test!")
+    flash("Test notification sent ", "success")
     return redirect(redirect_settings)

--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -300,6 +300,7 @@ def drive_eject(id):
     drive.open_close()
     db.session.commit()
     return redirect(redirect_settings)
+    
 
 @route_settings.route('/testapprise')
 def testapprise():
@@ -313,3 +314,4 @@ def testapprise():
     ripper_utils.notify("/dev/null", "ARM notification", "This is a notification by the ARM-Notification Test!")
     flash("Test notification sent ", "success")
     return redirect(redirect_settings)
+ 

--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -300,7 +300,7 @@ def drive_eject(id):
     drive.open_close()
     db.session.commit()
     return redirect(redirect_settings)
-    
+
 
 @route_settings.route('/testapprise')
 def testapprise():
@@ -314,4 +314,3 @@ def testapprise():
     ripper_utils.notify("/dev/null", "ARM notification", "This is a notification by the ARM-Notification Test!")
     flash("Test notification sent ", "success")
     return redirect(redirect_settings)
- 

--- a/arm/ui/settings/templates/settings/apprise.html
+++ b/arm/ui/settings/templates/settings/apprise.html
@@ -1,5 +1,6 @@
 {% block apprise %}
 <div class="tab-pane pt-5" id="appriseTab" role="tabpanel" aria-labelledby="apprise-tab">
+<a class="btn btn-primary float-left" href="testapprise">Send Test Notification</a>
     <form id="appriseCfg" name="appriseCfg" method="post" action="">
         {{ form.hidden_tag() }}
         {% for k, v in apprise_cfg.items() %}


### PR DESCRIPTION
# Description
Adds a route and UI button to send a test notification through Apprise. It will send a single message, with the same header as the regular notifications.

Fixes # (issue title here)
N/A

## Type of change
Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker

In my test setup, Apprise is configured to post to Telegram.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Add `testapprise` route to server, and button on the Apprise config page

# Logs
Here is a screenshot of the notification in action:
![IMG_6462](https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/596194/9e8e22c3-714b-47b4-86f6-2b4e9bf587f1)
