### PR TITLE
Fix bad use of "ln -sf"

### DIFF
--- a/scripts/docker/runit/arm_user_files_setup.sh
+++ b/scripts/docker/runit/arm_user_files_setup.sh
@@ -66,4 +66,6 @@ ln -sf /etc/arm/config/abcde.conf /etc/abcde.conf
 chown arm:arm /etc/abcde.conf /etc/arm/config/abcde.conf
 
 # symlink $ARM_HOME/Music to $ARM_HOME/music because the config for abcde doesn't match the docker compose docs
-ln -sf $ARM_HOME/Music $ARM_HOME/music
+# separate rm and ln commands because "ln -sf" does the wrong thing if dest is a symlink to a directory
+rm -f $ARM_HOME/music
+ln -s $ARM_HOME/Music $ARM_HOME/music


### PR DESCRIPTION
# Description
Changes an `ln -sf` into separate `rm -f` and `ln -s` commands, because `ln -sf` doesn't do what's expected if the destination is already a link to a directory.

Fixes #985  (Incorrect ln -sf in startup script means that ARM can't restart if ~arm/Music is on a CIFS/Samba share)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.

Changed `arm_user_files_setup.sh` as in this PR, and ARM then restarted smoothly. Without this change, and with a docker `-v` option that maps `/home/arm/Music` to a samba share, restarting ARM after running it and shutting it down won't work. (see bug description)

Please also list any relevant details for your test configuration

- [X] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Change 1: split `ln -sf` into `rm -f` and `ln -s`

# Logs
Attach logs from successful test runs here
