### PR TITLE
Allow disabling auto-ejects

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -201,6 +201,9 @@ class Job(db.Model):
 
     def eject(self):
         """Eject disc if it hasn't previously been ejected"""
+        if not cfg.arm_config['AUTO_EJECT']:
+            logging.info("Skipping auto eject")
+            return
         if not self.ejected:
             self.ejected = True
             try:

--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -32,6 +32,7 @@
   "GET_AUDIO_TITLE": "# Set to one of \"none\", \"musicbrainz\", \"freecddb\"\n# if \"musicbrainz\" is used the disc information are asked from musicbrainz.org\n# if \"none\" is used no label is identified",
   "RIP_POSTER": "# Rip DVD Posters from JACKET_P folder\n# Requires FFmpeg",
   "UNIDENTIFIED_EJECT": "# Auto-eject unidentified discs (blank etc)\n# May want to set this to false on certain (Pioneer slim) drives to prevent the immediate eject\n# issue (https://github.com/automatic-ripping-machine/automatic-ripping-machine/issues/779)",
+  "AUTO_EJECT": "# Auto-ejects disks\n# Auto-ejects disks when complete etc\n# Set to false to disable auto-ejection",
   "ABCDE_CONFIG_FILE": "# Location of your ABCDE config file",
   "RAW_PATH": "# Path to raw MakeMKV directory\n# Destination for MakeMKV and source for HandBrake",
   "TRANSCODE_PATH": "# Intermediary directory for transcoding files\n# Destination for HandBrake",

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -108,6 +108,12 @@ RIP_POSTER: false
 UNIDENTIFIED_EJECT: true
 
 
+# Auto-ejects disks
+# Auto-ejects disks when complete etc
+# Set to false to disable auto-ejection
+AUTO_EJECT: true
+
+
 #####################
 ## Directory setup ##
 #####################


### PR DESCRIPTION
# Description
Do not auto eject if disabled.

For me personally auto eject means my disc gets launched onto the floor, and I don't want to scratch my disks.


## Type of change
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Tested locally

- [X] Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Add setting option and ability to skip eject

# Logs
Relevant section:
```MSG:5036,260,1,"Copy complete. 1 titles saved.","Copy complete. %1 titles saved.","1"
[11-29-2023 00:12:01] INFO ARM: Skipping auto eject
[11-29-2023 00:12:01] INFO ARM: Exiting MakeMKV processing with return value of: /home/arm/media/raw/...```
