### PR TITLE
Make the installation/how-to/contributing links longer and easier to click

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,18 +63,18 @@ See: https://b3n.org/automatic-ripping-machine
 
 ## Install
 
-For normal installation please see the [wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/).
+[For normal installation please see the wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/).
 
-For docker installation please see [here](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/docker).
+[For docker installation please see here](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/docker).
 
 ## Troubleshooting
- Please see the [wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/).
+ [Please see the wiki for troubleshooting](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/).
 
 ## Contributing
 
 Pull requests are welcome.  Please see the [Contributing Guide](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Contributing-Guide)
 
-If you set ARM up in a different environment (hardware/OS/virtual/etc.), please consider submitting a howto to the [wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki).
+If you set ARM up in a different environment (hardware/OS/virtual/etc.), please consider [submitting a howto to the wiki](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki).
 
 ## License
 


### PR DESCRIPTION
made the links for installation docs longer to make them easier to click

# Description
I was having trouble clicking these links that were just "here" and "wiki" etc., so I made the link text longer and easier to click.

## Type of change

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Simply a markdown change. :)

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Made readme.md click targets bigger