### PR TITLE
Images Fix for Reverse Proxy

### DIFF
--- a/arm/ui/settings/templates/settings/apprise.html
+++ b/arm/ui/settings/templates/settings/apprise.html
@@ -12,7 +12,7 @@
                    value="{{ v }}" aria-describedby="{{ k }}">
             <a class="popovers" onClick='return false;' href="" data-content="{{ jsoncomments[k]| replace(" #", "\n")
             }}" rel="popover" data-placement="top" data-original-title="{{ k }}">
-            <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+            <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                  height="35px" alt="More Info">
             </a>
         </div>

--- a/arm/ui/settings/templates/settings/general.html
+++ b/arm/ui/settings/templates/settings/general.html
@@ -18,10 +18,10 @@
                         <li class="list-group-item">Update Available:
                         <!-- Update A.R.M -->
                             {% if stats['updated'] %}
-                                <img src="{{ url_for('static', filename='/img/success.png') }}"
+                                <img src="{{ url_for('static', filename='img/success.png') }}"
                                  alt="update image" width="20px" height="20px">  You are on the latest version
                             {% else %}
-                                <img src="{{ url_for('static', filename='/img/fail.png') }}"
+                                <img src="{{ url_for('static', filename='img/fail.png') }}"
                                  alt="update image" width="20px" height="20px">
                                 <form id="updateArm" name="updateArm" method="post" action="">
                                     {{ form.hidden_tag() }}

--- a/arm/ui/settings/templates/settings/help.html
+++ b/arm/ui/settings/templates/settings/help.html
@@ -6,19 +6,19 @@
                 <div class="row">
                     <div class="col-lg-4">
                         <a class="stretched-link text-center" target="_blank" rel="noopener" href="https://github.com/automatic-ripping-machine/automatic-ripping-machine">
-                            <img class="rounded mx-auto d-block mt-2" alt="GitHub" src="{{ url_for('static', filename='/img/github/GitHub-Mark-120px-plus.png') }}">
+                            <img class="rounded mx-auto d-block mt-2" alt="GitHub" src="{{ url_for('static', filename='img/github/GitHub-Mark-120px-plus.png') }}">
                             <label> Github </label>
                         </a>
                     </div>
                     <div class="col-lg-4 rounded">
                         <a target="_blank" rel="noopener" class="stretched-link text-center" href="https://discord.gg/FUSrn8jUcR">
-                            <img class="rounded mx-auto d-block mt-2" src="{{ url_for('static', filename='/img/discord/discord-128.png') }}" alt="Discord">
+                            <img class="rounded mx-auto d-block mt-2" src="{{ url_for('static', filename='img/discord/discord-128.png') }}" alt="Discord">
                             <label>Discord</label>
                         </a>
                     </div>
                     <div class="col-lg-4">
                         <a class="stretched-link text-center" target="_blank" rel="noopener" href="https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki">
-                            <img class="rounded mx-auto d-block mt-2" src="{{ url_for('static', filename='/img/github/GitHub-Mark-120px-plus.png') }}" alt="A.R.M Wiki - Help">
+                            <img class="rounded mx-auto d-block mt-2" src="{{ url_for('static', filename='img/github/GitHub-Mark-120px-plus.png') }}" alt="A.R.M Wiki - Help">
                             <label>A.R.M Wiki</label>
                         </a>
                     </div>

--- a/arm/ui/settings/templates/settings/ripper.html
+++ b/arm/ui/settings/templates/settings/ripper.html
@@ -12,7 +12,7 @@
                     <a class="popovers" onClick='return false;' href=""
                        data-content="{{ jsoncomments[k]| replace("#", "\n") }}" rel="popover"
                        data-placement="top" data-original-title="{{ k }}">
-                        <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                        <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                              height="35px" alt="More Info">
                     </a>
                 </div>

--- a/arm/ui/settings/templates/settings/settings.html
+++ b/arm/ui/settings/templates/settings/settings.html
@@ -47,7 +47,7 @@
             <div class="col">
                 <div class="jumbotron" style="padding-top: 1rem;">
                     <div class="col-sm-12  rounded text-center">
-                        <img src="{{ url_for('static', filename='/img/arm80.png') }}" alt="Automatic Ripping Machine">
+                        <img src="{{ url_for('static', filename='img/arm80.png') }}" alt="Automatic Ripping Machine">
                         <h2> ARM - Settings </h2>
                     </div>
                     <!-- Nav Tabs -->

--- a/arm/ui/settings/templates/settings/sysinfo.html
+++ b/arm/ui/settings/templates/settings/sysinfo.html
@@ -127,45 +127,45 @@
                         <!-- INTEL -->
                         <li class="list-group-item text-center">
                             Intel QuickSync: {% if stats['hw_support']['intel'] %}
-                            <img src="{{ url_for('static', filename='/img/success.png') }}"
+                            <img src="{{ url_for('static', filename='img/success.png') }}"
                                  alt="update image" width="20px" height="20px">
                         {% else %}
-                            <img src="{{ url_for('static', filename='/img/fail.png') }}"
+                            <img src="{{ url_for('static', filename='img/fail.png') }}"
                                  alt="update image" width="20px" height="20px">
                             <a href="https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/"
                                target=”_blank”>
                                 <img title="Get Help from the wiki!"
-                                     src="{{ url_for('static', filename='/img/info.png') }}" width="20px"
+                                     src="{{ url_for('static', filename='img/info.png') }}" width="20px"
                                      height="20px" alt="Get Help from the wiki!"></a>
                         {% endif %}
                         </li>
                         <!-- NVIDIA -->
                         <li class="list-group-item text-center">
                             Nvidia NVENC:{% if stats['hw_support']['nvidia'] %}
-                            <img src="{{ url_for('static', filename='/img/success.png') }}"
+                            <img src="{{ url_for('static', filename='img/success.png') }}"
                                  alt="update image" width="20px" height="20px">
                         {% else %}
-                            <img src="{{ url_for('static', filename='/img/fail.png') }}"
+                            <img src="{{ url_for('static', filename='img/fail.png') }}"
                                  alt="update image" width="20px" height="20px">
                             <a href="https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/"
                                target=”_blank”>
                                 <img title="Get Help from the wiki!"
-                                     src="{{ url_for('static', filename='/img/info.png') }}" width="20px"
+                                     src="{{ url_for('static', filename='img/info.png') }}" width="20px"
                                      height="20px" alt="Get Help from the wiki!"></a>
                         {% endif %}
                         </li>
                         <!-- AMD -->
                         <li class="list-group-item text-center">
                             AMD VCN:{% if stats['hw_support']['amd'] %}
-                            <img src="{{ url_for('static', filename='/img/success.png') }}"
+                            <img src="{{ url_for('static', filename='img/success.png') }}"
                                  alt="update image" width="20px" height="20px">
                         {% else %}
-                            <img src="{{ url_for('static', filename='/img/fail.png') }}"
+                            <img src="{{ url_for('static', filename='img/fail.png') }}"
                                  alt="update image" width="20px" height="20px">
                             <a href="https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/"
                                target=”_blank”>
                                 <img title="Get Help from the wiki!"
-                                     src="{{ url_for('static', filename='/img/info.png') }}" width="20px"
+                                     src="{{ url_for('static', filename='img/info.png') }}" width="20px"
                                      height="20px" alt="Get Help from the wiki!"></a>
                         {% endif %}
                         </li>

--- a/arm/ui/settings/templates/settings/ui.html
+++ b/arm/ui/settings/templates/settings/ui.html
@@ -13,7 +13,7 @@
                    data-content="{{ jsoncomments['index_refresh']| replace("#", "\n") }}"
                    rel="popover"
                    data-placement="top" data-original-title="index_refresh">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -28,7 +28,7 @@
                    data-content="{{ jsoncomments['notify_refresh']| replace("#", "\n") }}"
                    rel="popover"
                    data-placement="top" data-original-title="notify_refresh">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -42,7 +42,7 @@
                 <a class="popovers" onClick='return false;' href=""
                    data-content="{{ jsoncomments['use_icons']| replace("#", "\n") }}" rel="popover"
                    data-placement="top" data-original-title="use_icons">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -58,7 +58,7 @@
                    data-content="{{ jsoncomments['save_remote_images']| replace("#", "\n") }}"
                    rel="popover"
                    data-placement="top" data-original-title="save_remote_images">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -74,7 +74,7 @@
                    data-content="{{ jsoncomments['bootstrap_skin']| replace("#", "\n") }}"
                    rel="popover"
                    data-placement="top" data-original-title="bootstrap_skin">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -89,7 +89,7 @@
                 <a class="popovers" onClick='return false;' href=""
                    data-content="{{ jsoncomments['language']| replace("#", "\n") }}" rel="popover"
                    data-placement="top" data-original-title="language">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>
@@ -105,7 +105,7 @@
                    data-content="{{ jsoncomments['database_limit']| replace("#", "\n") }}"
                    rel="popover"
                    data-placement="top" data-original-title="database_limit">
-                    <img title="More information" src="{{ url_for('static', filename='/img/info.png') }}" width="30px"
+                    <img title="More information" src="{{ url_for('static', filename='img/info.png') }}" width="30px"
                          height="35px" alt="More info">
                 </a>
             </div>


### PR DESCRIPTION
# Description
Running Arm behind a reverse proxy (like nginx) works well with the exception of these image paths which accidently have a double // in the resulting html.

![image](https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/9733444/f23b9537-0ed1-41e4-8a69-fa2a33161198)

![image](https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/9733444/529d1add-59ab-4c32-953d-b85df51344d8)


## Type of change
Please delete options that are not relevant.

- [X ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Build the docker image, confirm that images are still displaying correctly

- [X] Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Remove duplicate slash in static image file paths

