### PR TITLE
bugfix for issue #1026 - typo in docker-setup.sh

### DIFF
--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -83,7 +83,7 @@ function save_start_command() {
     if [ -e start_arm_container.sh ]
     then
         echo -e "'start_arm_container.sh' already exists. Backing up..."
-        sudo mv /start_arm_container.sh ./start_arm_container.sh.bak
+        sudo mv ./start_arm_container.sh ./start_arm_container.sh.bak
     fi
     sudo -u arm curl -fsSL "$url" -o start_arm_container.sh
     chmod +x start_arm_container.sh

--- a/scripts/docker-setup.sh
+++ b/scripts/docker-setup.sh
@@ -99,4 +99,4 @@ pull_image
 setup_mountpoints
 save_start_command
 
-echo -e "${RED}Installation complete. A template command to run the ARM container is located in: $(~arm) ${NC}"
+echo -e "${RED}Installation complete. A template command to run the ARM container is located in: $(echo ~arm) ${NC}"


### PR DESCRIPTION
# Description
Typo in docker-setup.sh setup script, missing reference to the local folder

Fixes #1026 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Docker script run, confirming correct output was generated

- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- line 86, updated the command to reference the correct folder (local folder reference './' as identified in the issue
- line 102, resolved the script not printing the arm user directory correctly, and reporting a failed user trying to access a directory

# Logs
Attach logs from successful test runs here

Initial run, no fix

```
...
docker.io/automaticrippingmachine/automatic-ripping-machine:latest
Creating mount points
./docker-setup.sh: line 102: /home/arm: Is a directory
Installation complete. A template command to run the ARM container is located in:  
```

Script following bugfix

```
...
Status: Image is up to date for automaticrippingmachine/automatic-ripping-machine:latest
docker.io/automaticrippingmachine/automatic-ripping-machine:latest
Creating mount points
'start_arm_container.sh' already exists. Backing up...
Installation complete. A template command to run the ARM container is located in: /home/arm 
```