### PR TITLE
fix: use job.title to show meaningful music notifications

### DIFF
--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -114,7 +114,7 @@ def main(logfile, job, protection=0):
         # Try to recheck music disc for auto ident
         music_brainz.main(job)
         if utils.rip_music(job, logfile):
-            utils.notify(job, constants.NOTIFY_TITLE, f"Music CD: {job.label} {constants.PROCESS_COMPLETE}")
+            utils.notify(job, constants.NOTIFY_TITLE, f"Music CD: {job.title} {constants.PROCESS_COMPLETE}")
             utils.scan_emby()
             # This shouldn't be needed. but to be safe
             job.status = "success"

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -105,7 +105,7 @@ def notify_entry(job):
                f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {job.config.MAINFEATURE}."
                f"Edit entry here: {display_address}/jobdetail?job_id={job.job_id}")
     elif job.disctype == "music":
-        notify(job, NOTIFY_TITLE, f"Found music CD: {job.label}. Ripping all tracks")
+        notify(job, NOTIFY_TITLE, f"Found music CD: {job.title}. Ripping all tracks")
     elif job.disctype == "data":
         notify(job, NOTIFY_TITLE, "Found data disc.  Copying data.")
     else:


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.
Notifications for music cds were using `job.label` which would be more often than not - None.
![image](https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/6699589/b1b09efa-3a15-4c46-8a5e-8e10399b5890)

Changing to use` job.title` produces much better notifications for music discs
![image](https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/6699589/bdc58071-7bab-4768-b731-4c2e91f19503)

Changing this 
Fixes # (issue title here)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Changed `job.label` to `job.title` when producing notifications for music discs

# Logs
Attach logs from successful test runs here
