### PR TITLE
Improve cover art retrieval / prevent errors

### DIFF
--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -145,7 +145,7 @@ def notify_exit(job):
                          f"Title(s) {errlist} failed to complete. ")
             logging.info(f"Transcoding completed with errors.  Title(s) {errlist} failed to complete. ")
         else:
-            utils.notify(job, constants.NOTIFY_TITLE, str(job.title) + constants.PROCESS_COMPLETE)
+            utils.notify(job, constants.NOTIFY_TITLE, f"{job.title} {constants.PROCESS_COMPLETE}")
 
 
 def move_files_post(hb_out_path, job):

--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -13,6 +13,7 @@ import werkzeug
 
 werkzeug.cached_property = werkzeug.utils.cached_property
 
+
 def main(disc):
     """
     Depending on the configuration musicbrainz is used
@@ -105,7 +106,7 @@ def music_brainz(discid, job):
         if 'disc' in infos:
             logging.debug(f"do have artwork?======{release['cover-art-archive']['artwork']}")
         elif 'cdstub' in infos:
-            logging.debug(f"do have artwork?======No (cdstub)")
+            logging.debug("do have artwork?======No (cdstub)")
         # Get our front cover if it exists
         if get_cd_art(job, infos):
             logging.debug("we got an art image")
@@ -200,7 +201,11 @@ def get_cd_art(job, infos):
     try:
         # Use the build-in images from coverartarchive if available
         if 'disc' in infos:
-            first_release_with_artwork = next((release for release in infos['disc']['release-list'] if release.get('cover-art-archive', {}).get('artwork') != "false"), None)
+            release_list = infos['disc']['release-list']
+            first_release_with_artwork = next(
+                (release for release in release_list if release.get('cover-art-archive', {}).get('artwork') != "false"),
+                None
+            )
 
             if first_release_with_artwork is not None:
                 artlist = mb.get_image_list(first_release_with_artwork['id'])
@@ -218,6 +223,7 @@ def get_cd_art(job, infos):
         u.database_updater(False, job)
         logging.error(f"get_cd_art ERROR: {exc}")
         return False
+
 
 def process_tracks(job, mb_track_list, is_stub=False):
     """

--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -12,8 +12,6 @@ from arm.ripper import utils as u
 import werkzeug
 
 werkzeug.cached_property = werkzeug.utils.cached_property
-from robobrowser import RoboBrowser  # noqa E402
-
 
 def main(disc):
     """
@@ -95,9 +93,19 @@ def music_brainz(discid, job):
         return ""
     try:
         # We never make it to here if the mb fails
-        artist = release['artist-credit'][0]['artist']['name']
+        if 'disc' in infos:
+            artist = release['artist-credit'][0]['artist']['name']
+            no_of_titles = infos['disc']['offset-count']
+        elif 'cdstub' in infos:
+            artist = infos['cdstub']['artist']
+            no_of_titles = infos['cdstub']['track-count']
+            new_year = ''
+
         logging.debug(f"artist====={artist}")
-        logging.debug(f"do have artwork?======{release['cover-art-archive']['artwork']}")
+        if 'disc' in infos:
+            logging.debug(f"do have artwork?======{release['cover-art-archive']['artwork']}")
+        elif 'cdstub' in infos:
+            logging.debug(f"do have artwork?======No (cdstub)")
         # Get our front cover if it exists
         if get_cd_art(job, infos):
             logging.debug("we got an art image")
@@ -111,7 +119,7 @@ def music_brainz(discid, job):
             'year_auto': new_year,
             'title': artist_title,
             'title_auto': artist_title,
-            'no_of_titles': infos['disc']['offset-count']
+            'no_of_titles': no_of_titles
         }
         u.database_updater(args, job)
     except Exception as exc:
@@ -191,39 +199,25 @@ def get_cd_art(job, infos):
     """
     try:
         # Use the build-in images from coverartarchive if available
-        if 'disc' in infos and infos['disc']['release-list'][0]['cover-art-archive']['artwork'] != "false":
-            artlist = mb.get_image_list(job.crc_id)
-            for image in artlist["images"]:
-                # We dont care if its verified ?
-                if "image" in image:
-                    args = {
-                        'poster_url': str(image["image"]),
-                        'poster_url_auto': str(image["image"])
-                    }
-                    u.database_updater(args, job)
-                    return True
-    except mb.WebServiceError as exc:
-        u.database_updater(False, job)
-        logging.error(f"get_cd_art ERROR: {exc}")
-    try:
-        # This uses roboBrowser to grab the amazon/3rd party image if it exists
-        browser = RoboBrowser(user_agent='ARM-v2_devel')
-        browser.open('https://musicbrainz.org/release/' + job.crc_id)
-        img = browser.select('.cover-art img')
-        # [<img src="https://images-eu.ssl-images-amazon.com/images/I/41SN9FK5ATL.jpg"/>]
-        # img[0].text
-        args = {
-            'poster_url': str(re.search(r'<img src="(.*)"', str(img)).group(1)),
-            'poster_url_auto': str(re.search(r'<img src="(.*)"', str(img)).group(1)),
-            'video_type': "Music"
-        }
-        u.database_updater(args, job)
-        return bool(job.poster_url)
-    except mb.WebServiceError as exc:
-        logging.error(f"get_cd_art ERROR: {exc}")
-        u.database_updater(False, job)
-        return False
+        if 'disc' in infos:
+            first_release_with_artwork = next((release for release in infos['disc']['release-list'] if release.get('cover-art-archive', {}).get('artwork') != "false"), None)
 
+            if first_release_with_artwork is not None:
+                artlist = mb.get_image_list(first_release_with_artwork['id'])
+                for image in artlist["images"]:
+                    # We dont care if its verified ?
+                    if "image" in image:
+                        args = {
+                            'poster_url': str(image["image"]),
+                            'poster_url_auto': str(image["image"])
+                        }
+                        u.database_updater(args, job)
+                        return True
+        return False
+    except mb.WebServiceError as exc:
+        u.database_updater(False, job)
+        logging.error(f"get_cd_art ERROR: {exc}")
+        return False
 
 def process_tracks(job, mb_track_list, is_stub=False):
     """

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -105,7 +105,7 @@ def notify_entry(job):
                f"Found disc: {job.title}. Disc type is {job.disctype}. Main Feature is {job.config.MAINFEATURE}."
                f"Edit entry here: {display_address}/jobdetail?job_id={job.job_id}")
     elif job.disctype == "music":
-        notify(job, NOTIFY_TITLE, f"Found music CD: {job.title}. Ripping all tracks")
+        notify(job, NOTIFY_TITLE, f"Found music CD: {job.label}. Ripping all tracks.")
     elif job.disctype == "data":
         notify(job, NOTIFY_TITLE, "Found data disc.  Copying data.")
     else:

--- a/arm/ui/constants.py
+++ b/arm/ui/constants.py
@@ -9,4 +9,4 @@ NO_JOB = "No job supplied"
 JSON_TYPE = "application/json"
 # Ripper
 NOTIFY_TITLE = "ARM notification"
-PROCESS_COMPLETE = " processing complete. "
+PROCESS_COMPLETE = "processing complete."


### PR DESCRIPTION
# Description
I noticed that when ripping certain CDs, the ARM UI will show unknown for State and ETA along with no cover art.
<img width="733" alt="Screenshot 2024-01-12 193044" src="https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/6699589/f72caf44-b40b-4a53-9abc-0f8458ced381">



The log files showed this:
**ERROR ARM: music_brainz.music_brainz Try 2 -  ERROR: 'NoneType' object has no attribute 'group'**
[ARM attempts to use robobrowser to find the cover art](https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/main/arm/ripper/music_brainz.py#L211-L219) but there is no cover art image on the page.

We end up trying to extract the image url from None - which is not a `WebServiceError` and get caught in the `Try 2` exception.
The error prevents updating the job with the current number of tracks.

**_Current Logic_**
The [code chooses the first release](https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/main/arm/ripper/music_brainz.py#L194) to find the cover art.

if there is no cover art present, it uses the [release id (same as job.crc_id)](https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/main/arm/ripper/music_brainz.py#L58-L60) to find the cover art image from musicbrainz release page.

The issue here is that if there is no cover art from the info json - there will not be an image on musicbrainz either.

This is the `info` for Mest - Destination Unknown CD: https://musicbrainz.org/ws/2/discid/5FRS8CUPDRvXXBnoE0Jpzw8SlXU-?inc=artist-credits+recordings

The first release does not have cover art but the second one does.

**_Proposed Change_**
I have changed the logic to loop through all the releases to find a release with cover art.
This also means we do not need to use RoboBrowser at all.

If an image exists, it will be shown and the tracks and ETA will be populated in the ARM UI
<img width="713" alt="Screenshot 2024-01-12 195920" src="https://github.com/automatic-ripping-machine/automatic-ripping-machine/assets/6699589/1966b647-6aaa-4408-9194-100ac6751bb5">

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Find cover art by looping through releases
- Remove white space from PROCESS_COMPLETE constant
- Update code that uses PROCESS_COMPLETE
- Added a `.` after `Ripping all tracks`

# Logs
Attach logs from successful test runs here
