### PR TITLE
Add Wiki troubleshooting section for Disk Tray Opens then Immediately…

### DIFF
--- a/arm_wiki/General-Troubleshooting.md
+++ b/arm_wiki/General-Troubleshooting.md
@@ -21,6 +21,22 @@ When a disc is inserted, udev rules should launch a script (scripts/arm_wrapper.
 
     The default location is `/home/arm/db/`
 
+## Disk Tray Opens then Immediately Closes
+
+This can cause a disk to get ripped multiple times in a row,
+especially if `ALLOW_DUPLICATES` is `True` (which may be the case for ripping TV shows).
+
+To fix this issue (on systems that use `sysctl`), you can run the following command.
+This will create a settings file that disables autoclose on the disk tray,
+and reloads sysctl with that settings file.
+It requires `root` privileges via `sudo`,
+and will persist across reboots.
+
+```bash
+printf "# Fix issue with DVD tray being autoclosed after rip is complete\ndev.cdrom.autoclose=0\n" | sudo tee /etc/sysctl.d/arm-uneject-fix.conf >/dev/null && \
+  sudo sysctl --load=/etc/sysctl.d/arm-uneject-fix.conf
+```
+
 ## Other problems
 - Check ARM log files 
   - The default location is /home/arm/logs/ (unless this is changed in your arm.yaml file) and is named after the dvd. These are very verbose.  You can filter them a little by piping the log through grep.  Something like


### PR DESCRIPTION
… Closes #1076 

# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes #1076.

After I set up ARM in a Docker environment, I had an issue where it would complete a rip, eject, and immediately close the disk tray, causing it to rip the same disk again. @mneimeyer shared their solution on the original issue I created, and this MR simply documents that in the troubleshooting section of the Wiki for other folks to use if they need it.

## Type of change
Please delete options that are not relevant.

- [X] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [X] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

N/A (documentation only)

# Logs

N/A (documentation only)
