### PR TITLE
Exempt workflows from version bump

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -8,6 +8,7 @@ on:
       # Don't run on changes to the below paths
       paths-ignore:
         - 'arm_wiki/**'
+        - '.github/**'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
# Description
This PR prevents changes to the github workflows from resulting in the erroneous release of a new version of ARM

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works
