### PR TITLE
Bug fix no1088 git hub test arm agains multiple python versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         # in this example, there is a newer version already installed, 3.7.7, so the older version will be downloaded
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11']
     steps:
     - uses: actions/checkout@v4
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,10 +57,10 @@ jobs:
     - uses: actions/checkout@v4
       with:
         submodules: true
-    - name: Set up Python 3.10
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Fix dependencies
       run: |
         sudo apt-get update && sudo apt-get install libgnutls28-dev libcurl4-openssl-dev libssl-dev libdiscid-dev


### PR DESCRIPTION
# Description
Make Github actions test againts multiple version of python instead of just version 3.10

Fixes #1088

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [x] Other (GitHub Actions)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Change the Hardcoded value of Python Version 3.10 to the Matrix value of Python Version.  Enabeling automated testing againts multiple versions.
- Added a version of python to the tests, version 3.11.  Now GitHub actions should complete tests againts python versions 3.8, 3.9, 3.10 and 3.11

# Logs
See the following github page on my branch.
https://github.com/SylvainMT/automatic-ripping-machine/actions/runs/8366717574

The checks of this pull request could also suffice.