### PR TITLE
Added documentation: locked database being when using CIFS mounts

### DIFF
--- a/arm_wiki/Docker-Troubleshooting.md
+++ b/arm_wiki/Docker-Troubleshooting.md
@@ -46,6 +46,10 @@ These can be changed to suit your needs
     -v "/my-media-path:/home/arm/media" \
 ```
 
+## My volume paths point to a CIFS mount - but now the database is locked
+This is caused by a byte-range lock on the mount by default.
+To fix this, the CIFS mount of your host needs the `nobrl` flag. 
+
 ## NVENC doesn't work
 
 Be sure that both variables for `NVIDIA_DRIVER_CAPABILITIES=all`


### PR DESCRIPTION
# Description
Added documentation: locked database being when using CIFS mounts

Fixes # (issue title here)

## Type of change
- [x] documentation update

# How Has This Been Tested?
- [x] Other: Spell check

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

# Changelog:

Include the details of changes made here
Added a section about CIFS mounts.
