### PR TITLE
docs: set docker url to one that doesn't require a login

### DIFF
--- a/arm_wiki/docker.md
+++ b/arm_wiki/docker.md
@@ -2,7 +2,7 @@
 
 ### **This is not compatible with the snap version of docker!**
 
-A pre-built image has been added to docker hub [HERE](https://hub.docker.com/repository/docker/automaticrippingmachine/automatic-ripping-machine).
+A pre-built image has been added to docker hub [HERE](https://hub.docker.com/r/automaticrippingmachine/automatic-ripping-machine).
 
 ## Installing Linux
 - Select the option to install all third-party drivers


### PR DESCRIPTION
# Description
The wiki instructions for docker had a link to the docker image on dockerhub that requires you to log in. this should instead point to the public facing repository page.

Fixes # (issue title here)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
n/a

- [ ] Docker
- [x] Other (n/a)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- updated wiki doc.

# Logs
n/a
