### PR TITLE
Wiki update - add docker volume explanation

### DIFF
--- a/arm_wiki/docker.md
+++ b/arm_wiki/docker.md
@@ -188,5 +188,5 @@ If using network shares, be aware that the performance of your A.R.M. installati
 *    `{media_volume_path}` is a location on the machine running on Fast SSD and plenty of space (20+ gigabytes for each concurrent Dual Layer DVDs or 100 gigabytes for each concurrent 4k blu-rays)
 *    `{media_volume_path}/completed` is a mounted network share
 
-If using a network share for the /home/arm volume, read this [section](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting#my-volume-paths-point-to-a-cifs-mount---but-now-the-database-is-locked) from [Docker Troubleshooting](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting)
+If using a network share for the `/home/arm` volume, read this [section](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting#my-volume-paths-point-to-a-cifs-mount---but-now-the-database-is-locked) from [Docker Troubleshooting](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting)
 

--- a/arm_wiki/docker.md
+++ b/arm_wiki/docker.md
@@ -41,25 +41,27 @@ The script will now:
 3. **Start Script**: Open up `start_arm_container.sh` in the text editor of your choice. 
     1. If the ARM user id is not 1000, enter that value for `ARM_UID`. If the returned value is 1000, delete that line from the script.
     
-   Example: `-e ARM_UID="1001"` 
+       Example: `-e ARM_UID="1001"` 
      
-    4. If the ARM group id is not 1000, enter that value for `ARM_GID`. If the returned value is 1000, delete that line from the script.
+    2. If the ARM group id is not 1000, enter that value for `ARM_GID`. If the returned value is 1000, delete that line from the script.
     
        Example: `-e ARM_GID="1001"`
 
-    3. Fill in the appropriate paths for the volumes being mounted. Only change the path on the left hand side, docker volumes are configured with "[local path]:[arm path]".
+    3. Fill in the appropriate paths for the volumes being mounted. Only change the path on the left hand side, docker volumes are configured with "[local path]:[arm path]". More information about volumes is found below under the heading: [Understanding Docker Volumes for A.R.M.](#understanding-docker-volumes-for-arm)
 
        Example: `-v "/home/arm:/home/arm"`
 
-    4. Fill in the list of CPU core threads to give the container in `--cpuset-cpus`. It's highly recommended to leave at least one core for the hypervisor to use, so the host machine doesn't get choked out during transcoding! Also, CPUs with multiple threads per core will be numbered in pairs. In the below example, only core #4 would be passed to ARM.
+    4. Fill in your CD, DVD and Blu-Ray drives. Each `--device="/dev/sr0:/dev/sr0" \` line gives A.R.M. access to an optical drive. Run the command `lsscsi -g`, this command will list all the drives (SSD, HD, Optical and others) found on your system.  For each Optical drive, the second column will have the "cd/dvd" entry, note the `/dev/sr#` (replace the pound sign # with the number) and add a device entry to your script.  By default the script has sr0 through sr3 entered.  Add or remove as necessary. You should have one entry for each "cd/dvd" that lsscsi -g finds.  
+
+    5. Fill in the list of CPU core threads to give the container in `--cpuset-cpus`. It's highly recommended to leave at least one core for the hypervisor to use, so the host machine doesn't get choked out during transcoding! Also, CPUs with multiple threads per core will be numbered in pairs. In the below example, only core #4 would be passed to ARM.
    
        Example: `--cpuset-cpus='5,6'`
 
-   5. Set the name of the docker image, the default is below, but can be user configured.
+   6. Set the name of the docker image, the default is below, but can be user configured.
       
       Example: `--name "automatic-ripping-machine"`
    
-   5. Save and close
+   7. Save and close
 
 
 4. **Permissions**: When starting the ARM docker container, if the ARM user ID and group ID from steps 1 and 2 are not set correctly ARM will not start. If the container does not start, check the docker logs.
@@ -134,3 +136,57 @@ docker container prune
 ```bash
 sudo ./start_arm_container.sh
 ```
+## Understanding Docker Volumes for A.R.M.
+
+In the `start_arm_container.sh` script you will find these lines:
+```
+    -v "<path_to_arm_user_home_folder>:/home/arm" \
+    -v "<path_to_music_folder>:/home/arm/music" \
+    -v "<path_to_logs_folder>:/home/arm/logs" \
+    -v "<path_to_media_folder>:/home/arm/media" \
+    -v "<path_to_config_folder>:/etc/arm/config" \
+```
+These create volumes. What are volumes? They are easily accessible locations on your computer where you can access, delete, and change files that are accessible by the A.R.M. docker container.  They are also persistent, meaning that you can delete the docker image as many times as you want (probably to update your version of arm described in the (Updating docker image)[#updating-docker-image] section above) without losing the contents of the volumes, as long as you rebuild the docker container (by re-running the `start_arm_container.sh` script) with these same volumes your previous settings, logs, database entries and completed rips will be there.  
+
+### Explaining the different parts of the volume options
+
+The script runs a single command, `docker run`  Each line corresponds to an option passed to the `docker run` command.  
+* `-v` means you are telling `docker run` you wish to specify a volume.
+* `"<path_to_arm_user_home_folder>:/home/arm"` is the volume description.  It takes the following form: "{Path_Outside_Of_Docker_Container}:{Path_Inside_Of_Docker_Container}" The script is pre-populated with the volumes needed by A.R.M.  If you fail to specify these volumes, the Docker will start but it will create temporary volumes that will be erased when the image is re-created.  So you are highly encouraged to specify them.
+* `\` simply tells the computer that there are more lines to the `docker run` command
+
+Before you run the `start_arm_container.sh` script, you must create the directories you specify on your computer, and these directories should be owned by the arm user and the arm group.
+
+### The purpose of each A.R.M. volumes
+
+Each volume specified in the default script is needed by A.R.M. The following is a short explanation of the purpose for each of the volumes.  Each explanation refers to the "{Path_Inside_Of_Docker_Container}" portion of each volume
+
+* `/home/arm`
+    * Is the home directory for the arm user.  This is where the different apps used by A.R.M. (HandBrake and MakeMKV) will store their settings files, It is also where A.R.M. will store its database files.
+    * The default recommended is to use `/home/arm` for the "{Path_Outside_Of_Docker_Container}" of the volume definition.
+* `/home/arm/music`
+    * This is where A.R.M. will store completed rips from Music CDs.  You can specify any location on your computer.
+    * The default recommended is: `/home/arm/music/` for the "{Path_Outside_Of_Docker_Container}" of the volume definition.
+* `/home/arm/logs`
+    * This is where A.R.M. will store the logs it creates.  It creates one new log file for each "job" it has (each disk it rips). The default recommended is: `/home/arm/logs`
+* `/home/arm/media`
+    * This is where A.R.M. will save your movies from DVDs and Blu-rays from completed rips as well as Data disk ISOs. A.R.M. will create subfolders in this directory, these are;
+        * `raw` - Where A.R.M. temporarily saves the files created by MakeMKV
+        * `transcode` - Where A.R.M. temporarily saves the files created by HandBrake
+        * `completed` - Where A.R.M. moves the files when it completes the rip
+    * It is strongly recommended that this volume has access to a large amount of fast (SSD) disk space.
+    * The default suggested location is `/home/arm/media` for the "{Path_Outside_Of_Docker_Container}" of the volume definition.
+* `/etc/arm/config`
+    * This is where A.R.M. will look for the configuration files `arm.yaml`, `apprise.yaml` and `abcde.conf`. If the files are present it will use them, if they are not present A.R.M. will copy fresh copies with all the defaults and use those.  You can edit these files manually here or you can edit them in the A.R.M. web interface by clicking on the "Arm Settings" button on the toolbar.
+    * The default suggested location is `/home/arm/config` for the "{Path_Outside_Of_Docker_Container}" of the volume definition.
+ 
+### An Important note about permissions.
+
+You can choose whichever location you want for each of these volumes. They can even be Mounted locations referring to network drives. However, every one of these volumes _**MUST**_ be readable and writable by the arm user.  For simplicity, we strongly recommend that these folders be created as the `arm` user. (Log in to your machine, as the arm user, create the folders, using the `mkdir` command and then add them to your `start_arm_container.sh` script.  After that start the container as described above.
+
+If using network shares, be aware that the performance of your A.R.M. installation will be greatly affected by how fast it can read and write to the network share.  If you want to use a network share for the _completed_ rips, a suggestion could be to create a mount point _inside_ the volume...
+*    `{media_volume_path}` is a location on the machine running on Fast SSD and plenty of space (20+ gigabytes for each concurrent Dual Layer DVDs or 100 gigabytes for each concurrent 4k blu-rays)
+*    `{media_volume_path}/completed` is a mounted network share
+
+If using a network share for the /home/arm volume, read this [section](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting#my-volume-paths-point-to-a-cifs-mount---but-now-the-database-is-locked) from [Docker Troubleshooting](https://github.com/automatic-ripping-machine/automatic-ripping-machine/wiki/Docker-Troubleshooting)
+


### PR DESCRIPTION
# Description
Added some explanation of what the volumes defined in the `start_arm_container.sh` script means to the docker installation wiki page.

## Type of change
Please delete options that are not relevant.

- [x] Documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] N/A

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Added an entry to the Docker Post-install steps to specify devices for the optical drives.
- Added an explanation of Docker Volumes
- Added an explanation of the purpose of each A.R.M. volume.
- Added suggested default volumes to make it easy to get started.
- Added an explanation of the necessity for each volume to be owned by the Arm user and group.
- Added an explanation on using mounted locations and network shares as volumes.

# Logs
Not applicable, only a wiki update.
