### PR TITLE
corrected link in for intel bash script

### DIFF
--- a/arm_wiki/intel-qsv.md
+++ b/arm_wiki/intel-qsv.md
@@ -37,7 +37,7 @@ You can either follow along the [commands](https://raw.githubusercontent.com/aut
 
  ```
  sudo apt install wget
- wget https://github.com/automatic-ripping-machine/automatic-ripping-machine/blob/main/scripts/ubuntu-quicksync.sh
+ wget https://raw.githubusercontent.com/automatic-ripping-machine/automatic-ripping-machine/main/scripts/ubuntu-quicksync.sh 
  sudo chmod +x ubuntu-quicksync.sh
  sudo ./ubuntu-quicksync.sh
  ```


### PR DESCRIPTION
# Description
I fixed the link in the intel quick sync wiki guide so that the wget command would grab the bash script text instead of the whole page with html included


Fixes # (issue title here)
This fixes the script listed in the intel quick sync guide
## Type of change
Please delete options that are not relevant.

- [X] This change requires a documentation update ( it is a documentation update)

# How Has This Been Tested?
I tested it by grabbing the wget command and seeing if it pulled a just the bash script test

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
Changed one line in the intel quick sync wiki

# Logs
no logs needed didn't change code base
