### PR TITLE
Bug fix for data_rips moving files to a network share.

### DIFF
--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -435,7 +435,7 @@ def rip_data(job):
         subprocess.check_output(cmd, shell=True).decode("utf-8")
         full_final_file = os.path.join(final_path, f"{str(job.label)}.iso")
         logging.info(f"Moving data-disc from '{incomplete_filename}' to '{full_final_file}'")
-        os.rename(incomplete_filename, full_final_file)
+        move_files_main(incomplete_filename, full_final_file, final_path)
         logging.info("Data rip call successful")
         success = True
     except subprocess.CalledProcessError as dd_error:


### PR DESCRIPTION
# Description
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. 
List any dependencies that are required for this change.

Fixes #1128 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [x] Other (Debian BareMetal Install)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Not necessary, single line change with self explanatory function call)
- [ ] I have made corresponding changes to the documentation (Not necessary, change is hidden from user, does not affect interaction with the app)
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Changed line 438 of the utils.py file, so that the rip_data function makes use of the utils.py move_files_main function instead of the os package to move the completed files.

# Logs
Attach logs from successful test runs here

```
[05-16-2024 22:51:06] INFO ARM: Checking for fstab entry.
[05-16-2024 22:51:06] INFO ARM: fstab entry is: /dev/sr0    /mnt/dev/sr0    udf,iso9660    users,noauto,exec,utf8    0    0
[05-16-2024 22:51:06] INFO ARM: Disc identified as data
[05-16-2024 22:51:06] INFO ARM: Ripping data disc to: /home/arm/media/raw/NEWWORLDS_171591426689/NEWWORLDS.part
1330644+0 records in
1330644+0 records out
681289728 bytes (681 MB, 650 MiB) copied, 138.244 s, 4.9 MB/s
[05-16-2024 22:53:25] INFO ARM: Moving data-disc from '/home/arm/media/raw/NEWWORLDS_171591426689/NEWWORLDS.part' to '/mnt/media/zimmerman/unidentified/NEWWORLDS_171591426689/NEWWORLDS.iso'
[05-16-2024 22:53:25] INFO ARM: Data rip call successful
[05-16-2024 22:53:25] INFO ARM: Trying to remove raw_path: '/home/arm/media/raw/NEWWORLDS_171591426689'
```
