### PR TITLE
Update udev rules to only check /dev/sr* devices.

### DIFF
--- a/setup/51-docker-arm.rules
+++ b/setup/51-docker-arm.rules
@@ -1,5 +1,4 @@
 # ID_CDROM_MEDIA_BD = Bluray
 # ID_CDROM_MEDIA_DVD = DVD
 # ID_CDROM_MEDIA_CD = CD
-ACTION=="change", SUBSYSTEM=="block", RUN+="/sbin/setuser arm /opt/arm/scripts/docker/docker_arm_wrapper.sh %k"
-
+KERNEL=="sr[0-9]", ACTION=="change", SUBSYSTEM=="block", ENV{ID_CDROM_MEDIA_STATE}!="blank", RUN+="/sbin/setuser arm /opt/arm/scripts/docker/docker_arm_wrapper.sh %k"


### PR DESCRIPTION
# Description

Updated udev rules to scan only /dev/sr* devices as the current ones will check if any `block` device changes. This was causing an infinite loop for my ZFS array as my ZFS array was being monitored by the `zed` daemon. 

Fixes #1138

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Tested by doing a bind mount of existing udev rules and doing a rip of a dvd.

- [X] Docker
- [ ] Other (Please state here)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Update udev rules to only scan /dev/sr* devices and only if they are not blank

# Logs
Attach logs from successful test runs here
[test.log](https://github.com/automatic-ripping-machine/automatic-ripping-machine/files/15491489/test.log)

