### PR TITLE
[BUGFIX] munge albumname to mitigate overwriting Unkown Album

### DIFF
--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -547,8 +547,7 @@ mungefilename ()
 ID_SUFFIX=$(cd-discid $CDROM | cut -f1 -d ' ')
 mungealbumname ()
 {
-        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'$ID_SUFFI\
-X,g)
+        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'$ID_SUFFIX,g)
 }
 
 # Custom genre munging:

--- a/setup/.abcde.conf
+++ b/setup/.abcde.conf
@@ -540,10 +540,16 @@ mungefilename ()
 #
 # Custom filename munging specific to album names:
 # By default this function will call the mungefilename function.
-#mungealbumname ()
-#{
-#	mungefilename $@
-#}
+#
+# Adjust albumname to not overwrite "Unkown Album" folders
+# for subsequent unknown discs.
+# 
+ID_SUFFIX=$(cd-discid $CDROM | cut -f1 -d ' ')
+mungealbumname ()
+{
+        mungefilename $(echo "$@" | sed s,'Unknown Album','Unknown Album_'$ID_SUFFI\
+X,g)
+}
 
 # Custom genre munging:
 # By default we just transform uppercase to lowercase. Not much of a fancy


### PR DESCRIPTION
# Description

Creates unique folder for CDs not identified by abcde.
So instead of:
$OUTPUT_FOLDER/Unknown Album/Unknown Artist/
We get
$OUTPUT_FOLDER/Unknown Album/Unknown Artist_$DISCID

Fixes #1142 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration
Have copied the configuration in to my $CONFIG_DIR/abcde.conf file for my docker instane and tested with 3 CDs that abcde can't identify, ARm now has separate folders for each CD

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Change 1
- Change 2

# Logs
Attach logs from successful test runs here
[music_cd_171949248038.log](https://github.com/user-attachments/files/16014413/music_cd_171949248038.log)

arm@armitage:/bucket/music/Unknown Artist$ ls -ltr
total 0
drwxr-xr-x 1 arm arm 170 Jun 27 22:54 'Unknown Album_3c055805'
drwxr-xr-x 1 arm arm 342 Jun 27 22:54 'Unknown Album_8811e50b'
drwxr-xr-x 1 arm arm 170 Jun 27 23:02 'Unknown Album_4b07b707'

