### PR TITLE
CDRDAO ripping for hybrid (data+audio) discs

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -130,8 +130,8 @@ class Job(db.Model):
         :return: None
         """
         if self.disctype == "music":
-            logging.debug("Disc is music.")
-            self.label = music_brainz.main(self)
+            logging.debug("Disc is hybrid Data+Audio.")
+            self.disctype = "hybrid"
         elif os.path.isdir(self.mountpoint + "/VIDEO_TS"):
             logging.debug(f"Found: {self.mountpoint}/VIDEO_TS")
             self.disctype = "dvd"

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -130,6 +130,7 @@ class Job(db.Model):
         :return: None
         """
         if self.disctype == "music":
+            # Assumption here is get_disc_type only gets called for a mountable FS, therefore if we're here and disctype is "music" then we're hybrid
             logging.debug("Disc is hybrid Data+Audio.")
             self.disctype = "hybrid"
         elif os.path.isdir(self.mountpoint + "/VIDEO_TS"):

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -138,7 +138,7 @@ def main(logfile, job, protection=0):
     # Type: Hybrid data+audio
     elif job.disctype == "hybrid":
         logging.info("Disc identified as hybrid data+audio")
-        if utils.rip_data(job):
+        if utils.rip_hybrid(job):
             utils.notify(job, constants.NOTIFY_TITLE, f"Data disc: {job.label} copying complete. ")
         else:
             logging.info("Data rip failed.  See previous errors.  Exiting.")

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -134,6 +134,16 @@ def main(logfile, job, protection=0):
             logging.info("Data rip failed.  See previous errors.  Exiting.")
         job.eject()
 
+    
+    # Type: Hybrid data+audio
+    elif job.disctype == "hybrid":
+        logging.info("Disc identified as hybrid data+audio")
+        if utils.rip_data(job):
+            utils.notify(job, constants.NOTIFY_TITLE, f"Data disc: {job.label} copying complete. ")
+        else:
+            logging.info("Data rip failed.  See previous errors.  Exiting.")
+        job.eject()
+    
     # Type: undefined
     else:
         logging.info("Couldn't identify the disc type. Exiting without any action.")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -484,7 +484,7 @@ def rip_hybrid(job):
     make_dir(final_path)
     logging.info(f"Ripping data disc to: {incomplete_filename}")
     # Added from pull 366
-    cmd = f'cdrdao read-cd --device "{job.devpath}" --datafile "{incomplete_filename}" "{incomplete_filename_toc}" {cfg.arm_config["HYBRID_RIP_PARAMETERS"]} 2>> ' \
+    cmd = f'cdrdao read-cd --device "{job.devpath}" --datafile "{incomplete_filename}" {cfg.arm_config["HYBRID_RIP_PARAMETERS"]} "{incomplete_filename_toc}" 2>> ' \
           f'{os.path.join(job.config.LOGPATH, job.logfile)}'
     logging.debug(f"Sending command: {cmd}")
     try:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -489,7 +489,7 @@ def rip_hybrid(job):
     logging.debug(f"Sending command: {cmd}")
     try:
         subprocess.check_output(cmd, shell=True).decode("utf-8")
-        subprocess.run(f'toc2cue "{incomplete_filename_toc}" "{final_path}\{str(job.label)}.cue" 2>> {os.path.join(job.config.LOGPATH, job.logfile)}')
+        subprocess.run(f'toc2cue "{incomplete_filename_toc}" "{final_path}/{str(job.label)}.cue" 2>> {os.path.join(job.config.LOGPATH, job.logfile)}')
         full_final_file = os.path.join(final_path, f"{str(job.label)}.bin")
         logging.info(f"Moving data-disc from '{incomplete_filename}' to '{full_final_file}'")
         move_files_main(incomplete_filename, full_final_file, final_path)

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -489,10 +489,10 @@ def rip_hybrid(job):
     logging.debug(f"Sending command: {cmd}")
     try:
         subprocess.check_output(cmd, shell=True).decode("utf-8")
-        subprocess.run(f'toc2cue "{incomplete_filename_toc}" "{final_path}/{str(job.label)}.cue" 2>> {os.path.join(job.config.LOGPATH, job.logfile)}')
         full_final_file = os.path.join(final_path, f"{str(job.label)}.bin")
         logging.info(f"Moving data-disc from '{incomplete_filename}' to '{full_final_file}'")
         move_files_main(incomplete_filename, full_final_file, final_path)
+        subprocess.run(f'toc2cue "{incomplete_filename_toc}" "{final_path}/{str(job.label)}.cue" 2>> {os.path.join(job.config.LOGPATH, job.logfile)}')
         logging.info("Data rip call successful")
         success = True
     except subprocess.CalledProcessError as dd_error:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -114,6 +114,8 @@ def notify_entry(job):
         notify(job, NOTIFY_TITLE, f"Found music CD: {job.label}. Ripping all tracks.")
     elif job.disctype == "data":
         notify(job, NOTIFY_TITLE, "Found data disc.  Copying data.")
+    elif job.disctype == "hybrid":
+        notify(job, NOTIFY_TITLE, "Found hybrid disc.  Copying data only.")
     else:
         notify(job, NOTIFY_TITLE, "Could not identify disc.  Exiting.")
         args = {'status': 'fail', 'errors': "Could not identify disc."}

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -499,7 +499,7 @@ def rip_hybrid(job):
     make_dir(final_path)
     logging.info(f"Ripping data disc to: {incomplete_filename}")
     # Added from pull 366
-    cmd = f'cdrdao read-cd --device "{job.devpath}" --datafile "{incomplete_filename}" "{incomplete_filename_toc}" 2>> ' \
+    cmd = f'cdrdao read-cd --read-raw --device "{job.devpath}" --datafile "{incomplete_filename}" "{incomplete_filename_toc}" 2>> ' \
           f'{os.path.join(job.config.LOGPATH, job.logfile)}'
     toc_cmd = f'toc2cue -s -C "{incomplete_filename_bin}" "{incomplete_filename_toc}" "{incomplete_filename_cue}" 2>> ' \
               f'{os.path.join(job.config.LOGPATH, job.logfile)}'
@@ -511,11 +511,11 @@ def rip_hybrid(job):
         except subprocess.CalledProcessError as tc_error:
             err = f"toc2cue failed with code: {tc_error.returncode}({tc_error.output})"
             logging.error(err)
-            # os.unlink(incomplete_filename)
+            os.unlink(incomplete_filename)
             args = {'status': 'fail', 'errors': err}
             database_updater(args, job)
-        # os.unlink(incomplete_filename)
-        # os.unlink(incomplete_filename_toc)
+        os.unlink(incomplete_filename)
+        os.unlink(incomplete_filename_toc)
         full_final_file = os.path.join(final_path, f"{str(job.label)}.bin")
         full_final_file_cue = os.path.join(final_path, f"{str(job.label)}.cue")
         logging.info(f"Fixing cue file")

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -115,7 +115,7 @@ def notify_entry(job):
     elif job.disctype == "data":
         notify(job, NOTIFY_TITLE, "Found data disc.  Copying data.")
     elif job.disctype == "hybrid":
-        notify(job, NOTIFY_TITLE, "Found hybrid disc.  Copying data only.")
+        notify(job, NOTIFY_TITLE, "Found hybrid disc.  Copying data+audio to bin/cue.")
     else:
         notify(job, NOTIFY_TITLE, "Could not identify disc.  Exiting.")
         args = {'status': 'fail', 'errors': "Could not identify disc."}
@@ -504,11 +504,12 @@ def rip_hybrid(job):
         # os.unlink(incomplete_filename)
         # os.unlink(incomplete_filename_toc)
         full_final_file = os.path.join(final_path, f"{str(job.label)}.bin")
-        full_final_file_cue = os.path.join(final_path, f"{str(job.label)}.bin")
-        logging.info(f"Moving data-disc from '{incomplete_filename}' to '{full_final_file}'")
+        full_final_file_cue = os.path.join(final_path, f"{str(job.label)}.cue")
+        logging.info(f"Moving data+audio from '{incomplete_filename}' to '{full_final_file}'")
         move_files_main(incomplete_filename_bin, full_final_file, final_path)
+        logging.info(f"Moving data+audio cue sheet from '{incomplete_filename_cue}' to '{full_final_file_cue}'")
         move_files_main(incomplete_filename_cue, full_final_file_cue, final_path)
-        logging.info("Data rip call successful")
+        logging.info("Data+audio rip call successful")
         success = True
     except subprocess.CalledProcessError as dao_error:
         err = f"Data rip failed with code: {dao_error.returncode}({dao_error.output})"

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -484,7 +484,7 @@ def rip_hybrid(job):
     make_dir(final_path)
     logging.info(f"Ripping data disc to: {incomplete_filename}")
     # Added from pull 366
-    cmd = f'cdrdao read-cd --device "{job.devpath}" --datafile "{incomplete_filename}" {cfg.arm_config["HYBRID_RIP_PARAMETERS"]} "{incomplete_filename_toc}" 2>> ' \
+    cmd = f'cdrdao read-cd --device "{job.devpath}" --datafile "{incomplete_filename}" "{incomplete_filename_toc}" 2>> ' \
           f'{os.path.join(job.config.LOGPATH, job.logfile)}'
     logging.debug(f"Sending command: {cmd}")
     try:

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -30,6 +30,19 @@ from arm.ripper import apprise_bulk
 
 NOTIFY_TITLE = "ARM notification"
 
+def fix_cue_file(file):
+    new_cue_file=""
+    with open(file,'r') as cue_file:
+        for line in cue_file.readlines():
+            if line[:6] == 'FILE "' and line[-9:] == '" BINARY\n':
+                filename = line[6:-9]
+                trimmed_filename = os.path.basename(filename)
+                new_line = f'FILE "{trimmed_filename}" BINARY\n'
+            else:
+                new_line = line
+            new_cue_file = new_cue_file + new_line
+    with open(file,'w') as cue_file:
+        cue_file.write(new_cue_file)
 
 def notify(job, title: str, body: str):
     """
@@ -505,6 +518,8 @@ def rip_hybrid(job):
         # os.unlink(incomplete_filename_toc)
         full_final_file = os.path.join(final_path, f"{str(job.label)}.bin")
         full_final_file_cue = os.path.join(final_path, f"{str(job.label)}.cue")
+        logging.info(f"Fixing cue file")
+        fix_cue_file(incomplete_filename_cue)
         logging.info(f"Moving data+audio from '{incomplete_filename}' to '{full_final_file}'")
         move_files_main(incomplete_filename_bin, full_final_file, final_path)
         logging.info(f"Moving data+audio cue sheet from '{incomplete_filename_cue}' to '{full_final_file_cue}'")


### PR DESCRIPTION
# Description
This patch adds cdrdao support, for ripping hybrid (data+audio) discs.
These are commonly found on video game discs from the 1990s and early 2000s, where the game music is stored as CD audio

cdrdao-1.2.5 is required for byte swapping functionality in the toc2cue utility. This generally isn't in most distribution repositories but can be found at https://sourceforge.net/projects/cdrdao/files/rel_1_2_5/

## Type of change
Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)
Currently hybrid discs fail to rip at all as they are identified as music discs, but abcde will fail to rip them as they contain data tracks

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [X] Docker
Installed on Debian 12 in docker and 120 discs including hybrid and data-only discs ripped successfully

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:
-Added cdrdao support for ripping hybrid discs

# Logs
Attach logs from successful test runs here
[Gangsters_172033177835.log](https://github.com/user-attachments/files/16123240/Gangsters_172033177835.log)
