### PR TITLE
Add Podman support

### DIFF
--- a/scripts/podman/README.md
+++ b/scripts/podman/README.md
@@ -1,6 +1,8 @@
 This is built off of the dev branch - so I built the container locally
 from the automatic-ripping machine git:
+
 podman build . -t arm:latest
+
 This puts the image in your local repo, which is called by these scripts
 if you'd like to use the public docker hub container, change the image to
 

--- a/scripts/podman/README.md
+++ b/scripts/podman/README.md
@@ -1,0 +1,15 @@
+This is built off of the dev branch - so I built the container locally
+from the automatic-ripping machine git:
+podman build . -t arm:latest
+This puts the image in your local repo, which is called by these scripts
+if you'd like to use the public docker hub container, change the image to
+
+docker.io/automaticrippingmachine/automatic-ripping-machine:latest
+
+Rather than letting arm take control of ~arm, I've directed it to ~arm/arm
+this prevents arm from trying to change permissions of ~arm and running into
+a bunch of SELinux issues.
+
+This script / quadlet also work with Intel Quicksync as is - I'm passing a 
+Intel Corporation Raptor Lake-P [Iris Xe Graphics] into my VM. I have nto tested with
+AMD VCN or Nvidia NVENC (yet)

--- a/scripts/podman/README.md
+++ b/scripts/podman/README.md
@@ -13,5 +13,5 @@ this prevents arm from trying to change permissions of ~arm and running into
 a bunch of SELinux issues.
 
 This script / quadlet also work with Intel Quicksync as is - I'm passing a 
-Intel Corporation Raptor Lake-P [Iris Xe Graphics] into my VM. I have nto tested with
+Intel Corporation Raptor Lake-P [Iris Xe Graphics] into my VM. I have not tested with
 AMD VCN or Nvidia NVENC (yet)

--- a/scripts/podman/arm.container
+++ b/scripts/podman/arm.container
@@ -1,0 +1,21 @@
+# Place this file in $HOME/.config/containers/systemd/
+# arm.container
+[Container]
+AddDevice=/dev/sr0:/dev/sr0
+AddDevice=/dev/sr1:/dev/sr1
+AddDevice=/dev/sr2:/dev/sr2
+AddDevice=/dev/sr3:/dev/sr3
+AddDevice=/dev/dri:/dev/dri
+ContainerName=arm
+Environment=ARM_UID=1000 ARM_GID=1000
+Image=localhost/arm:latest
+PublishPort=8080:8080
+UIDMap=+1000:@1000
+Volume=%h/arm:/home/arm:Z
+Volume=%h/arm/music:/home/arm/music:Z
+Volume=%h/arm/logs:/home/arm/logs:Z
+Volume=%h/arm/media:/home/arm/media:Z
+Volume=%h/arm/config:/etc/arm/config:Z
+
+[Service]
+Restart=always

--- a/scripts/podman/podman_prep.sh
+++ b/scripts/podman/podman_prep.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# First lets make sure podman is installed
+dnf -yq install podman
+
+# Now we'll creat our arm user and add them to cdrom and render groups
+useradd arm -G cdrom,render
+
+# Give arm user SystemD linger - allows processes to run after their session ends
+loginctl enable-linger arm
+
+# Create arm and SystemD container directories
+mkdir -p ~arm/arm/{config,logs,media,music} ~arm/.config/containers/systemd
+chown -R arm:arm ~arm
+
+# Update firewall-d to allow port 8080
+firewall-cmd --permanent --add-port=8080/tcp
+firewall-cmd --reload

--- a/scripts/podman/podman_prep.sh
+++ b/scripts/podman/podman_prep.sh
@@ -11,6 +11,7 @@ loginctl enable-linger arm
 
 # Create arm and SystemD container directories
 mkdir -p ~arm/arm/{config,logs,media,music} ~arm/.config/containers/systemd
+cp arm.container ~/arm/.config/containers/systemd
 chown -R arm:arm ~arm
 
 # Update firewall-d to allow port 8080

--- a/scripts/podman/start_arm_podman.sh
+++ b/scripts/podman/start_arm_podman.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+podman run -d \
+    --uidmap="+1000:@1000"\
+    -p "8080:8080" \
+    -e ARM_UID="1000" \
+    -e ARM_GID="1000" \
+    -v "$HOME/arm:/home/arm:Z" \
+    -v "$HOME/arm/music:/home/arm/music:Z" \
+    -v "$HOME/arm/logs:/home/arm/logs:Z" \
+    -v "$HOME/arm/media:/home/arm/media:Z" \
+    -v "$HOME/arm/config:/etc/arm/config:Z" \
+    --device="/dev/sr0:/dev/sr0" \
+    --device="/dev/sr1:/dev/sr1" \
+    --device="/dev/sr2:/dev/sr2" \
+    --device="/dev/sr3:/dev/sr3" \
+    --device="/dev/dri:/dev/dri" \
+    --restart "always" \
+    --name "arm" \
+    localhost/arm:latest
+


### PR DESCRIPTION
# Title Add Podman support
_Add either feature or bugfix to the title inline with the software version increment_
New Feature - Podman support
Patch or Bugfix - Patch

# Description
Adds script to start arm via podman (start_arm_podman.sh) a script to prepare OS for podman usage (similar to docker-setup.sh) and finally the quadlet which is responsible for running podman. This was tested on Fedora Workstation 41 VM, with an  Intel Corporation Raptor Lake-P [Iris Xe Graphics] (rev 04) passed through to the VM.

Fixes # initial commit

## Type of change
Please delete options that are not relevant.


- [ X ] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
I have tested these against the dev 3.0 branch, as well as the publicly available ARM container - they work with both.

docker.io/automaticrippingmachine/automatic-ripping-machine:latest

- [ ] Docker
- [ X  ] Other (Podman)

# Checklist:

- [ X ] My code follows the style guidelines of this project
- [ X  ] I have performed a self-review of my own code
- [ X ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X ] My changes generate no new warnings
- [ X ] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
Added:
automatic-ripping-machine/scripts/podman/arm.container
automatic-ripping-machine/scripts/podman/podman_prep.sh
automatic-ripping-machine/scripts/podman/arm.container
automatic-ripping-machine/scripts/podman/arm.container

# Logs
Dec 05 11:56:34 fedora arm[3794]: *** Booting runit daemon...
Dec 05 11:56:34 fedora arm[3794]: *** Runit started as PID 55
Dec 05 11:56:34 fedora arm[3794]: Starting web ui
Dec 05 11:56:34 fedora arm[3794]: Dec  5 16:56:34 f2399dfe079b cron[58]: (CRON) INFO (pidfile fd = 3)
Dec 05 11:56:34 fedora arm[3794]: Dec  5 16:56:34 f2399dfe079b cron[58]: (CRON) INFO (Running @reboot jobs)
Dec 05 11:56:34 fedora arm[3794]: [2024-12-05 16:56:34,513] INFO ARM: __init__.<module> Setting log level to: INFO
Dec 05 11:56:34 fedora arm[3794]: [2024-12-05 16:56:34,618] INFO ARM: runui.<module> Starting ARM-UI on interface address - 192.168.1.91:8080
Dec 05 11:56:34 fedora arm[3794]: [2024-12-05 16:56:34,625] INFO ARM: wasyncore.log_info Serving on http://192.168.1.91:8080
Dec 05 11:57:36 fedora arm[3794]: [2024-12-05 16:57:36,515] INFO ARM: settings.check_hw_transcode_support Intel QuickSync supported!
Dec 05 11:57:36 fedora arm[3794]: [2024-12-05 16:57:36,515] INFO ARM: settings.check_hw_transcode_support Handbrake call successful

