### PR TITLE
[BUGFIX] Fix MINLENGTH for track.process

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -171,7 +171,8 @@ def process_single_tracks(job, logfile, rawpath, mode: str):
             cmd = f'makemkvcon mkv {job.config.MKV_ARGS} -r ' \
                   f'--progress={os.path.join(job.config.LOGPATH, "progress", str(job.job_id))}.log ' \
                   f'--messages=-stdout ' \
-                  f'dev:{job.devpath} {track.track_number} {shlex.quote(rawpath)}'
+                  f'dev:{job.devpath} {track.track_number} {shlex.quote(rawpath)} ' \
+                  f'--minlength={job.config.MINLENGTH}'
             run_makemkv(cmd, logfile)
 
 


### PR DESCRIPTION
# Description
Commit d087730 removed MINLENGTH from being passed to makemkv for single track.
As a result, makemkv would use default of 120s for such conditions.
If the user specifies MINLENGTH <120s, unexpected behavior occurs, such as jobs erroring out and jobs finishing without the desired titles.

I don't know if there is any particular reason for the original removal, so please confirm whether there is some case I haven't considered. But it resolved the issue in my testing.

Fixes #1299

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Ripped DVD with settings:
Drive Mode auto
MINLENGTH 55
MAXLENGTH 75
RIPMETHOD mkv
MAINFEATURE False

- [x] Docker

Ubuntu 22.04.5
A.R.M version: 2.10.5
Current git version: 1ce96f3

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

- Add --minlength argument to makemkvcon command in process_single_tracks()

# Logs
[Schoolhouse_Rock_Disc2_173899117509.log](https://github.com/user-attachments/files/18717089/Schoolhouse_Rock_Disc2_173899117509.log)

