### PR TITLE
[BUGFIX] Fix for "invalid literal for int() with base 10: 'A1'"

### DIFF
--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -242,7 +242,15 @@ def process_tracks(job, mb_track_list, is_stub=False):
                 track_leng = int(track['recording']['length'])
         except ValueError:
             logging.error("Failed to find track length")
-        trackno = track.get('number', idx + 1)
+
+        # Get Track ID
+        # Check if track is returned as a string like 'A1' for Vinyl
+        if isinstance(track.get('number', idx + 1), str):
+            trackno = track.get('position', idx + 1)
+            logging.info(f"Using Track 'position' as 'number' <str> track: {trackno}")
+        else:
+            trackno = track.get('number', idx + 1)
+
         if is_stub:
             title = track.get('title', f"Untitled track {trackno}")
         else:


### PR DESCRIPTION
# Description
Bugfix for issue raised #1315 
When ripping a cd, the track number comes back as 'A1' for incorrectly identified discs.
Bugfix runs a string check against the returned number, if a string will then use the position field

```json
...
'track-list':[
    {
        'id':'8ed112e1-af3e-4d5c-b3c8-bcbd4ccab165',
        'position':'1',
        'number':'A1',
        'length':'13440',
        }
...
```

Fixes # (issue title here)

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [x] Other (Pending user feedback)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Bugfix to music_brainz.py

# Logs
Pending user feedback
