### PR TITLE
added timezone env variable to start_arm_container.sh

### DIFF
--- a/scripts/docker/start_arm_container.sh
+++ b/scripts/docker/start_arm_container.sh
@@ -3,6 +3,7 @@ docker run -d \
     -p "8080:8080" \
     -e ARM_UID="<id -u arm>" \
     -e ARM_GID="<id -g arm>" \
+    -e TZ="<timedatectl show -p Timezone --value>" \
     -v "<path_to_arm_user_home_folder>:/home/arm" \
     -v "<path_to_music_folder>:/home/arm/music" \
     -v "<path_to_logs_folder>:/home/arm/logs" \


### PR DESCRIPTION
# Description
Timezone defaults to UTC when TZ isn't set. Users may forget or not know to set their timezone when using this script if an option doesn't appear for it. This makes users aware they can set their timezone if desired.

Fixes # Add Timezone env variable to docker container script - [PATCH]

## Type of change
- [x] Quality of Life improvement

# How Has This Been Tested?
Not tested yet, will test in a few days from now...

- [x ] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Added env variable to script that starts the docker container

# Logs
Attach logs from successful test runs here
