### PR TITLE
[BUGFIX] Gracefully handle DVD-Audio discs

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ See: https://b3n.org/automatic-ripping-machine
     - Transcoding jobs are asynchronously batched from ripping
     - Send notifications via IFTTT, Pushbullet, Slack, Discord, and many more!
   - If audio (CD) - rip using abcde (get disc-data and album art from [musicbrainz](https://musicbrainz.org/))
-  - If data (Blu-ray, DVD, or CD) - make an ISO backup
+  - If data (Blu-ray, DVD, DVD-Audio or CD) - make an ISO backup
 - Headless, designed to be run from a server
 - Can rip from multiple-optical drives in parallel
 - Python Flask UI to interact with ripping jobs, view logs, update jobs, etc

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -136,6 +136,12 @@ class Job(db.Model):
         if self.disctype == "music":
             logging.debug("Disc is music.")
             self.label = music_brainz.main(self)
+        elif (os.path.isdir(self.mountpoint + "/AUDIO_TS")
+              and len(os.listdir(self.mountpoint + "/AUDIO_TS")) > 0) \
+            or (os.path.isdir(self.mountpoint + "/audio_ts")
+                and len(os.listdir(self.mountpoint + "/audio_ts")) > 0):
+            logging.debug(f"Found: {self.mountpoint}/AUDIO_TS")
+            self.disctype = "data"
         elif os.path.isdir(self.mountpoint + "/VIDEO_TS"):
             logging.debug(f"Found: {self.mountpoint}/VIDEO_TS")
             self.disctype = "dvd"


### PR DESCRIPTION
# Description

DVD-Audio discs have a VIDEO_TS folder even though it often remains empty. This causes ARM to think that a DVD-Video disc is inserted and use makemkv, even though it'll inevitably fail because there's no VIDEO_TS. This PR simply checks if there is anything in the AUDIO_TS folder, and subsequently marks the disc as a `data` type disc.

There are DVD-Audio discs with DVD-Video content, which is probably all the more reason to simply treat DVD-Audio discs as data discs instead of trying to do anything else with them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with my own legally obtained (i.e purchased) DVD-Audio discs with my patch applied to the Docker image at runtime.

- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

- Switch `disctype` to `data` when a non-empty AUDIO_TS folder is detected.

# Logs

```
[04-13-2025 02:06:25] INFO ARM: identify.identify Mounting disc to: /mnt/dev/sr0
[04-13-2025 02:06:25] DEBUG ARM: identify.check_if_mounted OS mounted value: 0
[04-13-2025 02:06:25] DEBUG ARM: identify.check_if_mounted OS findmnt -M value: 0
[04-13-2025 02:06:25] INFO ARM: identify.check_if_mounted Mounting disc was successful
[04-13-2025 02:06:25] DEBUG ARM: job.get_disc_type Found: /mnt/dev/sr0/AUDIO_TS
...
[04-13-2025 02:07:25] INFO ARM: main.main Disc identified as data
```
