### PR TITLE
[BUGFIX] Improve the description of the DELRAWFILES settings value

### DIFF
--- a/arm/ui/comments.json
+++ b/arm/ui/comments.json
@@ -54,7 +54,7 @@
   "MAKEMKV_PERMA_KEY": "# Storage for a purchased key the user may have paid for. Populating will prevent the beta key updater from running.",
   "RIPMETHOD": "# Method of MakeMKV to use for Blu Ray discs.  Options are \"mkv\", \"backup\" or \"backup_dvd\".\n# backup decrypts the dvd and then copies it to the hard drive.  This allows HandBrake to apply some of it's\n# analytical abilities such as the main-feature identification.  This method seems to offer success on bluray \n# discs that fail in \"mkv\" mode. *** NOTE: MakeMKV only supports the backup or backup_dvd method on BluRay discs.\n# backup_dvd forces arm to extract the dvd with MakeMKV prior to the Handbrake step",
   "MKV_ARGS": "# MakeMKV Arguments\n# MakeMKV Profile used for controlling Audio Track Selection.\n# This is the default profile MakeMKV uses for Audio track selection. Updating this file or changing it is considered\n# to be advanced usage of MakeMKV. But this will allow users to alternatively tell makemkv to select HD audio tracks and etc.\n# MKV_ARGS: \"--profile=/opt/arm/default.mmcp.xml\"\n# MKV_ARGS: \"--debug=-stdout\"  # this will enable more detailed logging",
-  "DELRAWFILES": "# Remove the files created by MakeMKV after processing is complete",
+  "DELRAWFILES": "# Remove any files created in the raw and transcode paths for the job after processing is complete",
   "HB_PRESET_DVD": "# Handbrake preset profile for DVDs\n# Execute \"HandBrakeCLI -z\" to see a list of all presets",
   "HB_PRESET_BD": "# Handbrake preset profile for Blurays\n# Execute \"HandBrakeCLI -z\" to see a list of all presets",
   "DEST_EXT": "# Extension of the final video file",

--- a/setup/arm.yaml
+++ b/setup/arm.yaml
@@ -216,7 +216,7 @@ RIPMETHOD_BR: "PLACEHOLDER"
 # MKV_ARGS: "--debug=-stdout"  # this will enable more detailed logging
 MKV_ARGS: ""
 
-# Remove the files created by MakeMKV after processing is complete
+# Remove any files created in the raw and transcode paths for the job after processing is complete
 DELRAWFILES: true
 
 


### PR DESCRIPTION
# Description

Changes the description of the `DELRAWFILES` config/settings value to communicate that this flag also enables/disables the deletion of Handbrake transcoded files in the `TRANSCODE_PATH` in addition to the MakeMKV files in the `RAW_PATH`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
YAML loaded successfully in Docker 

- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Improve the description of the DELRAWFILES settings value

# Logs
N/A
