### PR TITLE
[BUGFIX] Resolve issue with regex on Linux CPU processor info

### DIFF
--- a/arm/models/system_info.py
+++ b/arm/models/system_info.py
@@ -59,7 +59,7 @@ class SystemInfo(db.Model):
                     self.cpu = str(amd_name) + " @ " + str(amd_ghz) + " GHz"
 
             # ARM64 CPU
-            arm_cpu = re.search(r"\\nmodel name\\t:(.*?)\\n", fulldump)
+            arm_cpu = re.search(r"model name\s*:\s*(.*)n", fulldump)
             logging.debug(f"ARM64 output: {arm_cpu}")
             if arm_cpu:
                 self.cpu = str(arm_cpu.group(1))[:19]

--- a/arm/models/system_info.py
+++ b/arm/models/system_info.py
@@ -2,6 +2,7 @@ import platform
 import psutil
 import re
 import subprocess
+import logging
 
 from arm.ui import db
 
@@ -27,37 +28,43 @@ class SystemInfo(db.Model):
         function to collect and return some cpu info
         ideally want to return {name} @ {speed} Ghz
         """
-        self.cpu = "Unknown"
+        self.cpu = "Unable to Identify"
+        logging.debug("****** Getting CPU Info ******")
+
         if platform.system() == "Windows":
             self.cpu = platform.processor()
         elif platform.system() == "Darwin":
             self.cpu = subprocess.check_output(['/usr/sbin/sysctl', "-n", "machdep.cpu.brand_string"]).strip()
         elif platform.system() == "Linux":
             command = "cat /proc/cpuinfo"
-            fulldump = str(subprocess.check_output(command, shell=True).strip())
+            # fulldump = subprocess.check_output(command, shell=True).strip()
+            fulldump = subprocess.check_output(command, shell=True).decode()
+            # logging.debug(f"Full cpuinfo: {fulldump}")
+
             # Take any float trailing "MHz", some whitespace, and a colon.
-            speeds = re.search(r"\\nmodel name\\t:.*?GHz\\n", fulldump)
-            if speeds:
-                # We have intel CPU
-                speeds = str(speeds.group())
-                speeds = speeds.replace('\\n', ' ')
-                speeds = speeds.replace('\\t', ' ')
-                speeds = speeds.replace('model name :', '')
-                self.cpu = speeds
+            # like: model name  : Intel(R) Celeron(R) G4930T CPU @ 3.00GHz
+            intel_match = re.search(r"model name\s*:\s*(.*?GHz)", fulldump)
+            logging.debug(f"Intel output: {intel_match}")
+            if intel_match:
+                self.cpu = intel_match.group(1)
+
             # AMD CPU
-            amd_name_full = re.search(r"model name\\t: (.*?)\\n", fulldump)
+            amd_name_full = re.search(r"model name\s*:\s*(.*)", fulldump)
+            logging.debug(f"AMD output: {amd_name_full}")
             if amd_name_full:
                 amd_name = amd_name_full.group(1)
-                amd_mhz = re.search(r"cpu MHz(?:\\t)*: ([.0-9]*)\\n", fulldump)  # noqa: W605
+                amd_mhz = re.search(r"cpu MHz\s*:\s*([.0-9]+)", fulldump)  # noqa: W605
                 if amd_mhz:
                     amd_ghz = round(float(amd_mhz.group(1)) / 1000, 2)  # this is a good idea
                     self.cpu = str(amd_name) + " @ " + str(amd_ghz) + " GHz"
+
             # ARM64 CPU
             arm_cpu = re.search(r"\\nmodel name\\t:(.*?)\\n", fulldump)
+            logging.debug(f"ARM64 output: {arm_cpu}")
             if arm_cpu:
                 self.cpu = str(arm_cpu.group(1))[:19]
-        else:
-            self.cpu = "N/A"
+
+        logging.debug("****************************")
 
     def get_memory(self):
         """ get the system total memory """

--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -407,10 +407,9 @@ def update_cpu():
         current_system.name = new_system.name
         current_system.cpu = new_system.cpu
         db.session.add(current_system)
-
     else:
-        app.logger.debug(f"Name old [] new [{new_system.name}]")
-        app.logger.debug(f"Name old [] new [{new_system.cpu}]")
+        app.logger.debug(f"Name old [No Info] new [{new_system.name}]")
+        app.logger.debug(f"Name old [No Info] new [{new_system.cpu}]")
         db.session.add(new_system)
 
     app.logger.debug("****** End System Information ******")


### PR DESCRIPTION
# Description
Resolves an issue with the regex for Linux based CPU systems

Fixes #1381 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [x] Other (Locally in PyCharm)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Updated, system_model with amended regex to correctly filter the Linux CPU information

# Logs

```bash
[2025-05-25 16:58:10,274] DEBUG ARM: settings.update_cpu ****** System Information ******
[2025-05-25 16:58:10,275] DEBUG ARM: settings.update_cpu Name old [ARM Server] new [ARM Server]
[2025-05-25 16:58:10,275] DEBUG ARM: settings.update_cpu Name old [Unable to Identify] new [11th Gen Intel(R) Core(TM) i5-1135G7 @ 2.40GHz]
[2025-05-25 16:58:10,275] DEBUG ARM: settings.update_cpu ****** End System Information ******
```
