### PR TITLE
Make NVIDIA install command copyable

### DIFF
--- a/arm_wiki/Hardware-Transcode-Nvidia-NVENC.md
+++ b/arm_wiki/Hardware-Transcode-Nvidia-NVENC.md
@@ -83,10 +83,12 @@ e.g. : `wget https://us.download.nvidia.com/XFree86/Linux-x86_64/570.144/NVIDIA-
 Do this before point 5 in post installation guide for docker "Run the container with sudo ./start_arm_container.sh" 
 
 1. Adding the repository:
-`curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
+```
+curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg \
   && curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
     sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
-    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list` 
+    sudo tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
+```
     
 2. Update repository
 `sudo apt-get update`


### PR DESCRIPTION
# Description
It's a command with line breaks, so a single-line code block didn't work.

## Type of change
It's just a documentation fix, so I removed the template...