### PR TITLE
[BUGFIX] Handle missing log directories more gracefully

### DIFF
--- a/arm/ripper/logger.py
+++ b/arm/ripper/logger.py
@@ -84,6 +84,9 @@ def clean_up_logs(logpath, loglife):
     for log_dir in logs_folders:
         logging.info(f"Checking path {log_dir} for old log files...")
         # Loop through each file in current folder and remove files older than set in arm.yaml
+        if not os.path.isdir(log_dir):
+            logging.info(f"{log_dir} is not a directory or doesn't exist. Skipping.")
+            continue
         for filename in os.listdir(log_dir):
             fullname = os.path.join(log_dir, filename)
             if fullname.endswith(".log") and os.stat(fullname).st_mtime < now - loglife * 86400:

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -211,15 +211,15 @@ if __name__ == "__main__":
     with open(os.path.join(cfg.arm_config["INSTALLPATH"], 'VERSION')) as version_file:
         version = version_file.read().strip()
 
-    # Delete old log files
-    logger.clean_up_logs(cfg.arm_config["LOGPATH"], cfg.arm_config["LOGLIFE"])
-    logging.info(f"Job: {job.label}")  # This will sometimes be none
-    # Check for zombie jobs and update status to 'failed'
-    utils.clean_old_jobs()
-    # Log all params/attribs from the drive
-    log_udev_params(devpath)
-
     try:
+        # Delete old log files
+        logger.clean_up_logs(cfg.arm_config["LOGPATH"], cfg.arm_config["LOGLIFE"])
+        logging.info(f"Job: {job.label}")  # This will sometimes be none
+        # Check for zombie jobs and update status to 'failed'
+        utils.clean_old_jobs()
+        # Log all params/attribs from the drive
+        log_udev_params(devpath)
+
         main(log_file, job, args.protection)
     except Exception as error:
         logging.error(error, exc_info=True)


### PR DESCRIPTION
# Description
I recently set up ARM on a bare metal Ubuntu 25.04 install (I'm hoping to do a writeup soon for that as well). Since there is more manual setup involved, I forgot to create the `logs/progress` directory, which caused the `main.py` script to crash inside the log cleanup function. When that happened, the exception wasn't logged in any of the logs, as far as I could tell, and the job was left in the database (and couldn't be abandoned since the PID was no longer is running).

This makes two small changes to better handle this scenario:

- Move the calls to the cleanup function inside the `try` block in `main.py`. That way if an exception is thrown during log cleanup, it is caught, logged, and the job is cleaned up properly.
- If any of the log directories are missing, log something and continue on to the next directory without throwing an exception.

This is my first contribution, and I'm happy to adjust the PR if anything isn't following the correct procedures, just let me know!

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [x] Other (Please state here)
 
I tested these on bare metal since I don't have docker, but it should be possible to test on docker as well, if you can build an image where you remove the `logs/progress` directory.

## Change to log cleanup
- Make sure your `logs/progress` directory does not exist
- Start a rip
- Verify that a message is logged during log cleanup indicating the progress directory was skipped
- Verify that the rip continues

## Change to top level exception handling
- Comment out the change in `logger.py` to continue when a logging directory is missing
- Start a rip
- Verify that the job throws an exception, but it is handled and logged, and the job is properly aborted

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Handle missing log directories during cleanup in `logger.py`
- Expand the scope of the top level try block in `main.py` so it handles exceptions in log cleanup

# Logs
Attach logs from successful test runs here
