### PR TITLE
[BUGFIX] Resolved musicbrain failing with wrong data type

### DIFF
--- a/arm/ripper/music_brainz.py
+++ b/arm/ripper/music_brainz.py
@@ -47,7 +47,7 @@ def music_brainz(discid, job):
     # Tell musicbrainz what your app is, and how to contact you
     # (this step is required, as per the webservice access rules
     # at http://wiki.musicbrainz.org/XML_Web_Service/Rate_Limiting )
-    mb.set_useragent(app="arm", version=job.arm_version, contact="https://github.com/automatic-ripping-machine")
+    mb.set_useragent(app="arm", version=str(job.arm_version), contact="https://github.com/automatic-ripping-machine")
     try:
         infos = mb.get_releases_by_discid(discid, includes=['artist-credits', 'recordings'])
         logging.debug(f"Infos: {infos}")
@@ -165,7 +165,7 @@ def get_title(discid, job):
     # Tell musicbrainz what your app is, and how to contact you
     # (this step is required, as per the webservice access rules
     # at http://wiki.musicbrainz.org/XML_Web_Service/Rate_Limiting )
-    mb.set_useragent("arm", version=job.arm_version, contact="https://github.com/automatic-ripping-machine")
+    mb.set_useragent("arm", version=str(job.arm_version), contact="https://github.com/automatic-ripping-machine")
     try:
         infos = mb.get_releases_by_discid(discid, includes=['artist-credits'])
         logging.debug(f"Infos: {infos}")


### PR DESCRIPTION
# Description
ARM update cdc7c1b resolved an issue calling 'v2_devel' as the ARM version; however, that update passed a non-string data type to the musicbrainz set_useragent function resulting in a crash.
Resolved the issue by wrapping the ARM version in a str() conversion

Fixes #1443 
See issue for previous error log

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- wrapped arm version in a string data type

# Logs
ARM music rip completed as expected, user agent call extract below

```bash
...
[2025-07-07 07:50:59] INFO ARM: main.check_fstab fstab entry is: /dev/sr0  /mnt/dev/sr0  udf,iso9660  users,noauto,exec,utf8,ro  0  0
[2025-07-07 07:50:59] DEBUG ARM: musicbrainz.set_useragent set user-agent to arm/2.16.1 python-musicbrainzngs/0.7.1 ( https://github.com/automatic-ripping-machine )
[2025-07-07 07:50:59] DEBUG ARM: musicbrainz._mb_request GET request for https://musicbrainz.org/ws/2/discid/KYCdtVrK5_Mo7aQWDBtYiS64CNg-?inc=artist-credits+recordings
[2025-07-07 07:50:59] DEBUG ARM: musicbrainz._mb_request requesting with UA arm/2.16.1 python-musicbrainzngs/0.7.1 ( https://github.com/automatic-ripping-machine )
...
```