### PR TITLE
[BUGFIX] fstring and dataclass generation

### DIFF
--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -1038,7 +1038,7 @@ class MakeMKVOutputChecker:
         log_message = self.data.message if debug_msg else error_msg
         log_func(log_message)
 
-        return MakeMKVErrorMessage(*self.data)
+        return MakeMKVErrorMessage(*dataclasses.astuple(self.data), self.data.message)
 
     def write_error(self):
         error_msg = self.data.sprintf[1]
@@ -1047,7 +1047,7 @@ class MakeMKVOutputChecker:
         else:
             logging.warning(error_msg)
 
-        return MakeMKVErrorMessage(*self.data)
+        return MakeMKVErrorMessage(*dataclasses.astuple(self.data), self.data.message)
 
     def special_error_code(self):
         return MakeMKVErrorMessage(*dataclasses.astuple(self.data), self.data.message)

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -690,7 +690,7 @@ def duplicate_run_check(dev_path):
     logging.critical(f'Drive {dev_path} has an active Job ({job.job_id}): {job.status}.')
     # log time
     job_time = ceil(job.run_time // 60)
-    logging.info("Job was started {job_time}min ago.")
+    logging.info(f"Job was started {job_time}min ago.")
     if (job_time) < 3:
         logging.info("Job was started less than 3min ago.")
     sys.exit(1)


### PR DESCRIPTION
# Description

Fixes unevaluated f-string causing malformed log timestamps and resolves TypeError when unpacking MakeMKVErrorMessage from a non-iterable dataclasses.
Improves log clarity and ensures proper error handling during MakeMKV execution.

## Type of change
Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [X] Docker

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

# Changelog:

Fix malformed f-string in log messages (ec400a05)

- The logging format introduced in 30f5a9e1 was missing an f-prefix on an f-string, resulting in incorrect timestamp display (e.g., missing minutes).

- This was evident in issue #1454 and is now resolved by correctly evaluating the f-string.

Fix TypeError when constructing MakeMKVErrorMessage (f0b8a575)

- A TypeError occurred when MakeMKVErrorMessage was called with a MakeMKVMessage instance, rather than an unpacked iterable.

- This caused failures during error handling in the ripping pipeline, as shown in log traces.

- The fix ensures that data is unpacked correctly when passed to the dataclass constructor.


# logs

```
[2025-07-26T115801] DEBUG ARM: makemkv.run MSG:2003,16777216,3,"Error 'Internal error - Input parameter is incorrect (489)' occurred while reading '/BDMV/STREAM/00021.m2ts' at offset '774144'","Error '%1' occurred while reading '%2' at offset '%3'","Internal error - Input parameter is incorrect (489)","/BDMV/STREAM/00021.m2ts","774144"
[2025-07-26T115801] WARNING ARM: makemkv.read_error Internal error - Input parameter is incorrect (489)
```