### PR TITLE
[BUGFIX] replace hard-coded paths with configurable ones

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -136,7 +136,7 @@ class Job(db.Model):
     def __init__(self, devpath):
         """Return a disc object"""
         self.devpath = devpath
-        self.mountpoint = "/mnt" + devpath
+        self.mountpoint = os.environ.get("RUNTIME_DIRECTORY", "/mnt") + devpath
         self.hasnicetitle = False
         self.video_type = "unknown"
         self.ejected = False

--- a/arm/ripper/ARMInfo.py
+++ b/arm/ripper/ARMInfo.py
@@ -47,7 +47,7 @@ class ARMInfo:
         Function to get the current arm git version
         """
         branch_len = 10
-        cmd = "cd /opt/arm && git branch && git log -1"
+        cmd = f"cd {self.install_path} && git branch && git log -1"
         git_output = ProcessHandler.arm_subprocess(cmd, True)
         git_regex = r"\*\s(\S+)\n(?:\s*\S*\n){1,10}(?:commit )([a-z\d]{5,7})"
         git_match = re.search(git_regex, str(git_output.decode("utf-8")))

--- a/arm/ripper/arm_ripper.py
+++ b/arm/ripper/arm_ripper.py
@@ -4,8 +4,13 @@ It would help clear up main and make things easier to find
 import sys
 import os
 import logging
+from importlib.util import find_spec
+from pathlib import Path
 
-sys.path.append("/opt/arm")
+# If the arm module can't be found, add the folder this file is in to PYTHONPATH
+# This is a bad workaround for non-existent packaging
+if find_spec("arm") is None:
+    sys.path.append(str(Path(__file__).parents[2]))
 
 from arm.ripper import utils, makemkv, handbrake  # noqa E402
 from arm.ui import app, db, constants  # noqa E402

--- a/arm/ripper/logger.py
+++ b/arm/ripper/logger.py
@@ -117,7 +117,9 @@ def create_logger(app_name, log_level=logging.DEBUG, stdout=True, syslog=False, 
 
     if file:
         # create file logger handler
-        file_handler = logging.FileHandler('/home/arm/logs/arm.log')
+        file_handler = logging.FileHandler(
+            os.path.join(cfg.arm_config['LOGPATH'], 'arm.log')
+        )
         file_handler.setLevel(log_level)
         file_handler.setFormatter(formatter)
         logger.addHandler(file_handler)

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -13,11 +13,15 @@ import time  # noqa: E402
 import datetime  # noqa: E402
 import re  # noqa: E402
 import getpass  # noqa E402
+from importlib.util import find_spec
+from pathlib import Path
 import pyudev  # noqa: E402
 import psutil  # noqa E402
 
-# set the PATH to /opt/arm so we can handle imports properly
-sys.path.append("/opt/arm")
+# If the arm module can't be found, add the folder this file is in to PYTHONPATH
+# This is a bad workaround for non-existent packaging
+if find_spec("arm") is None:
+    sys.path.append(str(Path(__file__).parents[2]))
 
 from arm.ripper import logger, utils, identify, arm_ripper, music_brainz  # noqa: E402
 import arm.config.config as cfg  # noqa E402

--- a/arm/ripper/makemkv.py
+++ b/arm/ripper/makemkv.py
@@ -816,10 +816,7 @@ def prep_mkv():
     """
     try:
         logging.info("Updating MakeMKV key...")
-        cmd = [
-            "/bin/bash",
-            "/opt/arm/scripts/update_key.sh",
-        ]
+        cmd = [os.path.join(cfg.arm_config["INSTALLPATH"], "scripts/update_key.sh")]
         # if MAKEMKV_PERMA_KEY is populated
         if cfg.arm_config['MAKEMKV_PERMA_KEY'] is not None and cfg.arm_config['MAKEMKV_PERMA_KEY'] != "":
             logging.debug("MAKEMKV_PERMA_KEY populated, using that...")
@@ -1076,7 +1073,7 @@ def run(options, select):
         raise TypeError(select)
     # robot process of makemkvcon with
     cmd = [
-        "/usr/local/bin/makemkvcon",
+        "makemkvcon",
         "--robot",
         "--messages=-stdout",
     ]

--- a/arm/ripper/utils.py
+++ b/arm/ripper/utils.py
@@ -85,7 +85,7 @@ def bash_notify(cfg, title, body):
     # bash notifications use subprocess instead of apprise.
     if cfg['BASH_SCRIPT'] != "":
         try:
-            subprocess.run(["/usr/bin/bash", cfg['BASH_SCRIPT'], title, body])
+            subprocess.run(["/usr/bin/env", "bash", cfg['BASH_SCRIPT'], title, body])
             logging.debug("Sent bash notification successful")
         except Exception as error:  # noqa: E722
             logging.error(f"Failed sending notification via bash. Continuing  processing...{error}")

--- a/arm/ui/settings/settings.py
+++ b/arm/ui/settings/settings.py
@@ -14,6 +14,7 @@ Covers
 - testapprise [GET]
 - updateCPU [GET]
 """
+import os
 import platform
 import importlib
 import re
@@ -380,7 +381,10 @@ def drive_manual(manual_id):
     drive = SystemDrives.query.filter_by(drive_id=manual_id).first()
     dev_path = drive.mount.lstrip('/dev/')
 
-    cmd = f"/opt/arm/scripts/docker/docker_arm_wrapper.sh {dev_path}"
+    cmd = os.path.join(
+        cfg.arm_config["INSTALLPATH"],
+        "scripts/docker/docker_arm_wrapper.sh {dev_path}",
+    )
     app.logger.debug(f"Running command[{cmd}]")
 
     # Manually start ARM if the udev rules are not working for some reason

--- a/scripts/docker/docker_arm_wrapper.sh
+++ b/scripts/docker/docker_arm_wrapper.sh
@@ -5,6 +5,10 @@ ARMLOG="/home/arm/logs/arm.log"
 echo "[ARM] Entering docker wrapper" | logger -t ARM -s
 echo "$(date) Entering docker wrapper" >> $ARMLOG
 
+set -a && source /etc/environment && set +a
+# ↑       ↑ set all env vars from this file (we need PATH, udev doesn't give it to us)
+# └ export all variables which are set
+
 #######################################################################################
 # YAML Parser to read Config
 #
@@ -66,4 +70,4 @@ else
 	  exit #bail out
 fi
 cd /home/arm
-/usr/bin/python3 /opt/arm/arm/ripper/main.py -d "${DEVNAME}" | logger -t ARM -s
+python3 /opt/arm/arm/ripper/main.py -d "${DEVNAME}" | logger -t ARM -s


### PR DESCRIPTION
Adhering to systemd standards for the environment variables.

## Description

All hard-coded paths can now be configured via environment variables. The names of the environment variables are chosen so that they can be read directly from systemd, if arm is started as a systemd service, see [systemd.exec(5)](https://man.archlinux.org/man/core/systemd/systemd.exec.5.en#SANDBOXING).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?
Ripped and transcoded a DVD successfully

- [x] Docker
- [x] Other (NixOS Module)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation 
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

## Changelog:

- Configs are read from `$CONFIGURATION_DIRECTORY`
- `$RUNTIME_DIRECTORY` is used for mountpoints
- `$STATE_DIRECTORY` is used for the DB
- `$LOGS_DIRECTORY` is used for the logs
- The default values are as before
- Read `$PATH` from `/etc/environment` in the docker wrapper so we can call makemkv without an absolute path
  - In my opinion, this is the better approach vs. a1df08d1b93ff25926d5983c1f186407ff236c63, because it is more general, that is why I haven't rebased onto main yet

## Logs
[EN-102281_175380153613.log](https://github.com/user-attachments/files/21493557/EN-102281_175380153613.log)

