### PR TITLE
[BUGFIX] Port track 99 detection to python

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -148,6 +148,7 @@ class Job(db.Model):
         self.stage = str(round(time.time() * 100))
         self.manual_start = False
         self.manual_mode = False
+        self.has_track_99 = False
 
         if self.disctype == "dvd" and not self.label:
             logging.info("No disk label Available. Trying lsdvd")

--- a/arm/ripper/ARMInfo.py
+++ b/arm/ripper/ARMInfo.py
@@ -50,7 +50,7 @@ class ARMInfo:
         cmd = "cd /opt/arm && git branch && git log -1"
         git_output = ProcessHandler.arm_subprocess(cmd, True)
         git_regex = r"\*\s(\S+)\n(?:\s*\S*\n){1,10}(?:commit )([a-z\d]{5,7})"
-        git_match = re.search(git_regex, str(git_output.decode("utf-8")))
+        git_match = re.search(git_regex, git_output)
 
         if git_match:
             (self.git_branch, self.git_commit) = git_match.groups()

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -17,8 +17,7 @@ def arm_subprocess(cmd, in_shell):
             shell=in_shell
         )
     except subprocess.CalledProcessError as error:
-        logging.error(f"Error executing command {cmd}")
-        logging.error(f"Subprocess error {error}")
+        logging.error(f"Error executing command `{cmd}`: {error}")
         arm_process = None
 
     return arm_process

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -6,7 +6,7 @@ import logging
 import subprocess
 
 
-def arm_subprocess(cmd, in_shell):
+def arm_subprocess(cmd, in_shell, check=False):
     """
     Handle creating new subprocesses and catch any errors
     """
@@ -18,5 +18,7 @@ def arm_subprocess(cmd, in_shell):
         )
     except subprocess.CalledProcessError as error:
         logging.error(f"Error executing command `{cmd}`: {error}")
+        if check:
+            raise error
 
     return arm_process

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -18,7 +18,10 @@ def arm_subprocess(cmd, in_shell, check=False):
             shell=in_shell
         )
     except subprocess.CalledProcessError as error:
-        logging.error(f"Error executing command `{cmd}`: {error}")
+        logging.error(error)
+        logging.error("Output was:")
+        logging.error(error.output)
+        logging.debug(str(error.__traceback__))
         if check:
             raise error
 

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -11,6 +11,7 @@ def arm_subprocess(cmd, in_shell, check=False):
     Handle creating new subprocesses and catch any errors
     """
     arm_process = None
+    logging.debug(f"Running command: {cmd}")
     try:
         arm_process = subprocess.check_output(
             cmd,

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -2,26 +2,41 @@
 Function definition
   Wrapper for the python subprocess module
 """
+
 import logging
 import subprocess
+from typing import Optional, List
 
 
-def arm_subprocess(cmd, in_shell, check=False):
+def arm_subprocess(cmd: str | List[str], shell=False, check=False) -> Optional[str]:
     """
-    Handle creating new subprocesses and catch any errors
+    Spawn blocking subprocess
+
+    :param cmd: Command to run
+    :param shell: Run ``cmd`` in a shell
+    :param check: Raise ``CalledProcessError`` if ``cmd`` returns non-zero exit code
+
+    :return: Output of ``cmd``, or ``None`` if it returned a non-zero exit code
+
+    :raise CalledProcessError:
     """
     arm_process = None
     logging.debug(f"Running command: {cmd}")
     try:
         arm_process = subprocess.check_output(
-            cmd,
-            shell=in_shell
+            cmd, shell=shell, encoding="utf-8"
         )
-    except subprocess.CalledProcessError as error:
-        logging.error(error)
-        logging.error("Output was:")
-        logging.error(error.output)
-        logging.debug(str(error.__traceback__))
+    except (subprocess.CalledProcessError, OSError) as error:
+        decoded_output = error.output.strip()
+        logging.error(
+            f"Error while running command: {cmd}\n"
+            + (
+                f"Output was: {decoded_output}"
+                if decoded_output
+                else "The command produced no output."
+            ),
+            exc_info=error,
+        )
         if check:
             raise error
 

--- a/arm/ripper/ProcessHandler.py
+++ b/arm/ripper/ProcessHandler.py
@@ -10,7 +10,7 @@ def arm_subprocess(cmd, in_shell):
     """
     Handle creating new subprocesses and catch any errors
     """
-    arm_process = ""
+    arm_process = None
     try:
         arm_process = subprocess.check_output(
             cmd,
@@ -18,6 +18,5 @@ def arm_subprocess(cmd, in_shell):
         )
     except subprocess.CalledProcessError as error:
         logging.error(f"Error executing command `{cmd}`: {error}")
-        arm_process = None
 
     return arm_process

--- a/arm/ripper/main.py
+++ b/arm/ripper/main.py
@@ -34,7 +34,6 @@ def entry():
     """ Entry to program, parses arguments"""
     parser = argparse.ArgumentParser(description='Process disc using ARM')
     parser.add_argument('-d', '--devpath', help='Devpath', required=True)
-    parser.add_argument('-p', '--protection', help='Does disc have 99 track protection', required=False)
     return parser.parse_args()
 
 
@@ -89,7 +88,7 @@ def check_fstab():
     logging.error("No fstab entry found.  ARM will likely fail.")
 
 
-def main(logfile, job, protection=0):
+def main(logfile, job):
     """main disc processing function"""
     logging.info("Starting Disc identification")
     identify.identify(job)
@@ -108,7 +107,7 @@ def main(logfile, job, protection=0):
     # Ripper type assessment for the various media types
     # Type: dvd/bluray
     if job.disctype in ["dvd", "bluray"]:
-        arm_ripper.rip_visual_media(have_dupes, job, logfile, protection)
+        arm_ripper.rip_visual_media(have_dupes, job, logfile, job.has_track_99)
 
     # Type: Music
     elif job.disctype == "music":
@@ -188,8 +187,6 @@ if __name__ == "__main__":
     utils.duplicate_run_check(devpath)
 
     logging.info(f"************* Starting ARM processing at {datetime.datetime.now()} *************")
-    if args.protection:
-        logging.warning("Found 99 Track protection system - Job may fail!")
     # Set job status and start time
     job.status = JobState.IDLE.value
     job.start_time = datetime.datetime.now()
@@ -222,7 +219,7 @@ if __name__ == "__main__":
     log_udev_params(devpath)
 
     try:
-        main(log_file, job, args.protection)
+        main(log_file, job)
     except Exception as error:
         logging.error(error, exc_info=True)
         logging.error("A fatal error has occurred and ARM is exiting.  See traceback below for details.")

--- a/scripts/docker/docker_arm_wrapper.sh
+++ b/scripts/docker/docker_arm_wrapper.sh
@@ -37,15 +37,6 @@ eval $(parse_yaml /etc/arm/config/arm.yaml "CONFIG_")
 # ID_CDROM_MEDIA_CD = CD
 # ID_CDROM_MEDIA_DVD = DVD
 if [ "$ID_CDROM_MEDIA_DVD" == "1" ]; then
-    if [ "$CONFIG_PREVENT_99" != "false" ]; then
-        numtracks=$(lsdvd /dev/"${DEVNAME}" 2> /dev/null | sed 's/,/ /' | cut -d ' ' -f 2 | grep -E '[0-9]+' | sort -r | head -n 1)
-        if [ "$numtracks" == "99" ]; then
-            echo "[ARM] ${DEVNAME} has 99 Track Protection. Bailing out and ejecting." | logger -t ARM -s
-            echo "$(date) [ARM] ${DEVNAME} has 99 Track Protection. Bailing out and ejecting." >> $ARMLOG
-            eject "${DEVNAME}"
-            exit
-        fi
-    fi
     echo "$(date) [ARM] Starting ARM for DVD on ${DEVNAME}" >> $ARMLOG
     echo "[ARM] Starting ARM for DVD on ${DEVNAME}" | logger -t ARM -s
 elif [ "$ID_CDROM_MEDIA_BD" == "1" ]; then

--- a/scripts/thickclient/arm_venv_wrapper.sh
+++ b/scripts/thickclient/arm_venv_wrapper.sh
@@ -42,16 +42,6 @@ eval "$(parse_yaml /etc/arm/config/arm.yaml "CONFIG_")"
 #######################################################################################
 
 if [ "$ID_CDROM_MEDIA_DVD" == "1" ]; then
- numtracks=$(lsdvd "/dev/${DEVNAME}" 2> /dev/null | sed 's/,/ /' | cut -d ' ' -f 2 | grep -E '[0-9]+' | sort -r | head -n 1)#
-	if [ "$numtracks" == "99" ]; then
-	  if [ "$CONFIG_PREVENT_99" == "true" ]; then
-		  echo "[ARM] ${DEVNAME} has 99 Track Protection...Ripping 99 is disabled.. Ejecting disc." | logger -t ARM -s
-			eject "$DEVNAME"
-		else
-			echo "[ARM] ${DEVNAME} has 99 Track Protection...Trying workaround" | logger -t ARM -s
-			PROTECTION="-p 1"
-		fi
-	fi
 	echo "[ARM] Starting ARM for DVD on ${DEVNAME}" | logger -t ARM -s
 
 elif [ "$ID_CDROM_MEDIA_BD" == "1" ]; then
@@ -69,7 +59,7 @@ else
 
 fi
 
-/bin/su -l -c "echo /opt/arm/venv/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} ${PROTECTION} | at now" -s /bin/bash ${USER}
+/bin/su -l -c "echo /opt/arm/venv/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} | at now" -s /bin/bash ${USER}
 
 #######################################################################################
 # Check to see if the admin page is running, if not, start it

--- a/scripts/thickclient/arm_wrapper.sh
+++ b/scripts/thickclient/arm_wrapper.sh
@@ -42,16 +42,6 @@ eval "$(parse_yaml /etc/arm/config/arm.yaml "CONFIG_")"
 #######################################################################################
 
 if [ "$ID_CDROM_MEDIA_DVD" == "1" ]; then
- numtracks=$(lsdvd "/dev/${DEVNAME}" 2> /dev/null | sed 's/,/ /' | cut -d ' ' -f 2 | grep -E '[0-9]+' | sort -r | head -n 1)#
-	if [ "$numtracks" == "99" ]; then
-	  if [ "$CONFIG_PREVENT_99" == "true" ]; then
-		  echo "[ARM] ${DEVNAME} has 99 Track Protection...Ripping 99 is disabled.. Ejecting disc." | logger -t ARM -s
-			eject "$DEVNAME"
-		else
-			echo "[ARM] ${DEVNAME} has 99 Track Protection...Trying workaround" | logger -t ARM -s
-			PROTECTION="-p 1"
-		fi
-	fi
 	echo "[ARM] Starting ARM for DVD on ${DEVNAME}" | logger -t ARM -s
 
 elif [ "$ID_CDROM_MEDIA_BD" == "1" ]; then
@@ -69,7 +59,7 @@ else
 
 fi
 
-/bin/su -l -c "echo /usr/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} ${PROTECTION} | at now" -s /bin/bash ${USER}
+/bin/su -l -c "echo /usr/bin/python3 /opt/arm/arm/ripper/main.py -d ${DEVNAME} | at now" -s /bin/bash ${USER}
 
 #######################################################################################
 # Check to see if the admin page is running, if not, start it

--- a/test/unittest/test_ripper_processhandler.py
+++ b/test/unittest/test_ripper_processhandler.py
@@ -14,7 +14,7 @@ class TestProcessHandler(unittest.TestCase):
         CHECK "arm_subprocess" returns the correct output
         """
         # Mock the subprocess.check_output function to return a mock output
-        mock_output = b"Hello, World!"
+        mock_output = "Hello, World!"
         mock_check_output.return_value = mock_output
 
         cmd = ["echo", "Hello, World!"]


### PR DESCRIPTION
## Description
Track 99 detection is now part of `arm.ripper.identify`. This makes ARM less dependent on wrapper scripts and more self-contained.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ripped and transcoded a DVD

- [x] Docker
- [x] Other (NixOS module)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have tested that my fix is effective or that my feature works
  - I don't have a DVD with track 99 so this still needs to be done. I'm very certain it will work though, I have verified that the parsing of `lsdvd` output works.

## Changelog:

- Changes to ProcessHandler (included here since I changed the function signature, hope that's okay)
  - Re-done the output format to be more concise
  - Pass through `check` argument to `subprocess.check_output`
  - Log command at debug level
  - On error, log command output
  - Decode output with UTF-8 by default instead of returning bytes
- Ported track 99 protection to Python

## Logs
[EN-102281_175387320486.log](https://github.com/user-attachments/files/21510064/EN-102281_175387320486.log)

