### PR TITLE
PATCH Update DebianInstaller.sh

### DIFF
--- a/scripts/installers/DebianInstaller.sh
+++ b/scripts/installers/DebianInstaller.sh
@@ -523,10 +523,10 @@ function PasswordProtectArmUser() {
     PasswordQuestion="${BLUE}The 'arm' user was already on the system.
 Do you wish to change it's password? Y/n : ${NC}"
   fi
+  local PasswordConfirmed=false
   if IsUserAnsweredYesToPrompt "${PasswordQuestion}" ; then
     #The User wishes to provide a custom password.  Give the user 3 times to provide one,
     #This attempt limit is to prevent an infinite loop.
-    local PasswordConfirmed=false
     for (( i = 0 ; i < 3 ; i++ )); do
       read -ep "$(echo -e "Please Enter Password? : ")" -r -s Password_1
       read -ep "$(echo -e "Please Confirm Password? : ")" -r -s Password_2


### PR DESCRIPTION
Fix $PaswordConfirmed uninitialized/undefined in line 557

# PATCH

# Description
The local variable `PaswordConfirmed` is uninitialized/undefined when evaluating line 557

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- [x] Other (Debian install script)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Moved declaration of `PaswordConfirmed` outside the if-statement
