### PR TITLE
Fix for org.opencontainers.image.version not being set correctly

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -100,10 +100,9 @@ jobs:
           tags: |
             ${{ env.IMAGE_NAME }}:${{ env.TAG }}
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
-          labels: ${{ steps.meta.outputs.labels }}
-          build-args: |
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-            VERSION=${{ env.IMAGE_VERSION }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            org.opencontainers.image.version=${{ env.VERSION }}
       
       # Fetches all tags for the repo
       - name: Fetch tags

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -101,7 +101,10 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ env.TAG }}
             ${{ env.IMAGE_NAME }}:${{ env.VERSION }}
           labels: ${{ steps.meta.outputs.labels }}
-
+          build-args: |
+            BUILD_DATE=${{ github.event.head_commit.timestamp }}
+            VERSION=${{ env.IMAGE_VERSION }}
+      
       # Fetches all tags for the repo
       - name: Fetch tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ FROM automaticrippingmachine/arm-dependencies:1.6.0 AS base
 LABEL org.opencontainers.image.source=https://github.com/automatic-ripping-machine/automatic-ripping-machine
 LABEL org.opencontainers.image.license=MIT
 LABEL org.opencontainers.image.description='Automatic Ripping Machine for fully automated Blu-ray, DVD and audio disc ripping.'
-
+ARG VERSION
+ARG BUILD_DATE
+LABEL org.opencontainers.image.version=$VERSION
+LABEL org.opencontainers.image.created=$BUILD_DATE
 EXPOSE 8080
 
 # Setup folders and fstab

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,7 @@ FROM automaticrippingmachine/arm-dependencies:1.6.0 AS base
 LABEL org.opencontainers.image.source=https://github.com/automatic-ripping-machine/automatic-ripping-machine
 LABEL org.opencontainers.image.license=MIT
 LABEL org.opencontainers.image.description='Automatic Ripping Machine for fully automated Blu-ray, DVD and audio disc ripping.'
-ARG VERSION
-ARG BUILD_DATE
-LABEL org.opencontainers.image.version=$VERSION
-LABEL org.opencontainers.image.created=$BUILD_DATE
+
 EXPOSE 8080
 
 # Setup folders and fstab


### PR DESCRIPTION
# [BUGFIX]

# Description
Quick fix to add the correct version to docker tags

Fixes #1452

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [ ] Docker
- [x] Other (Github actions)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Added hardcoded container tags described here: https://github.com/docker/metadata-action?tab=readme-ov-file#customizing

# Logs
logs available via github action logs.