### PR TITLE
[BUGFIX] Fix burned UDF DVD-Rs misidentified as data discs due to stale file handle

### DIFF
--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -19,6 +19,27 @@ from arm.models.track import Track  # noqa: F401
 from arm.models.config import Config  # noqa: F401
 
 
+def _disc_dir_exists(mountpoint, name):
+    """Check if a directory name exists in a disc mountpoint.
+
+    Uses os.listdir on the parent rather than os.path.isdir on the target,
+    to handle burned UDF discs where the directory entry is visible in the
+    listing but os.stat() fails with a stale file handle.
+    """
+    try:
+        return name.upper() in [e.upper() for e in os.listdir(mountpoint)]
+    except OSError:
+        return False
+
+
+def _listdir_safe(path):
+    """Return os.listdir(path), or [] if the path is inaccessible."""
+    try:
+        return os.listdir(path)
+    except OSError:
+        return []
+
+
 class JobState(str, enum.Enum):
     """Possible states for Job.status.
 
@@ -205,51 +226,19 @@ class Job(db.Model):
         :param found_hvdvd_ts:  gets pushed in from utils - saves importing utils
         :return: None
         """
-        # Use listdir on the mountpoint root to detect disc structure.
-        # os.path.isdir() can fail with OSError (e.g. stale file handle) on
-        # burned UDF discs where the directory entry exists but the inode is
-        # unreadable. Checking the parent listing avoids that issue.
-        try:
-            mount_contents = [e.upper() for e in os.listdir(self.mountpoint)]
-        except OSError:
-            mount_contents = []
-
-        def dir_in_mount(name):
-            """Check for directory by name in mountpoint listing, falling back
-            to os.path.isdir if the name isn't visible in the listing."""
-            if name.upper() in mount_contents:
-                return True
-            try:
-                return os.path.isdir(self.mountpoint + "/" + name)
-            except OSError:
-                return False
-
-        def listdir_safe(path):
-            """os.listdir but returns [] on any error."""
-            try:
-                return os.listdir(path)
-            except OSError:
-                return []
-
         if self.disctype == "music":
             logging.debug("Disc is music.")
             self.label = music_brainz.main(self)
-        elif (dir_in_mount("AUDIO_TS")
-              and len(listdir_safe(self.mountpoint + "/AUDIO_TS")) > 0) \
-            or (dir_in_mount("audio_ts")
-                and len(listdir_safe(self.mountpoint + "/audio_ts")) > 0):
+        elif _disc_dir_exists(self.mountpoint, "AUDIO_TS") and _listdir_safe(self.mountpoint + "/AUDIO_TS"):
             logging.debug(f"Found: {self.mountpoint}/AUDIO_TS")
             self.disctype = "data"
-        elif dir_in_mount("VIDEO_TS"):
+        elif _disc_dir_exists(self.mountpoint, "VIDEO_TS"):
             logging.debug(f"Found: {self.mountpoint}/VIDEO_TS")
             self.disctype = "dvd"
-        elif dir_in_mount("video_ts"):
-            logging.debug(f"Found: {self.mountpoint}/video_ts")
-            self.disctype = "dvd"
-        elif dir_in_mount("BDMV"):
+        elif _disc_dir_exists(self.mountpoint, "BDMV"):
             logging.debug(f"Found: {self.mountpoint}/BDMV")
             self.disctype = "bluray"
-        elif dir_in_mount("HVDVD_TS"):
+        elif _disc_dir_exists(self.mountpoint, "HVDVD_TS"):
             logging.debug(f"Found: {self.mountpoint}/HVDVD_TS")
             # do something here
         elif found_hvdvd_ts:

--- a/arm/models/job.py
+++ b/arm/models/job.py
@@ -205,25 +205,51 @@ class Job(db.Model):
         :param found_hvdvd_ts:  gets pushed in from utils - saves importing utils
         :return: None
         """
+        # Use listdir on the mountpoint root to detect disc structure.
+        # os.path.isdir() can fail with OSError (e.g. stale file handle) on
+        # burned UDF discs where the directory entry exists but the inode is
+        # unreadable. Checking the parent listing avoids that issue.
+        try:
+            mount_contents = [e.upper() for e in os.listdir(self.mountpoint)]
+        except OSError:
+            mount_contents = []
+
+        def dir_in_mount(name):
+            """Check for directory by name in mountpoint listing, falling back
+            to os.path.isdir if the name isn't visible in the listing."""
+            if name.upper() in mount_contents:
+                return True
+            try:
+                return os.path.isdir(self.mountpoint + "/" + name)
+            except OSError:
+                return False
+
+        def listdir_safe(path):
+            """os.listdir but returns [] on any error."""
+            try:
+                return os.listdir(path)
+            except OSError:
+                return []
+
         if self.disctype == "music":
             logging.debug("Disc is music.")
             self.label = music_brainz.main(self)
-        elif (os.path.isdir(self.mountpoint + "/AUDIO_TS")
-              and len(os.listdir(self.mountpoint + "/AUDIO_TS")) > 0) \
-            or (os.path.isdir(self.mountpoint + "/audio_ts")
-                and len(os.listdir(self.mountpoint + "/audio_ts")) > 0):
+        elif (dir_in_mount("AUDIO_TS")
+              and len(listdir_safe(self.mountpoint + "/AUDIO_TS")) > 0) \
+            or (dir_in_mount("audio_ts")
+                and len(listdir_safe(self.mountpoint + "/audio_ts")) > 0):
             logging.debug(f"Found: {self.mountpoint}/AUDIO_TS")
             self.disctype = "data"
-        elif os.path.isdir(self.mountpoint + "/VIDEO_TS"):
+        elif dir_in_mount("VIDEO_TS"):
             logging.debug(f"Found: {self.mountpoint}/VIDEO_TS")
             self.disctype = "dvd"
-        elif os.path.isdir(self.mountpoint + "/video_ts"):
+        elif dir_in_mount("video_ts"):
             logging.debug(f"Found: {self.mountpoint}/video_ts")
             self.disctype = "dvd"
-        elif os.path.isdir(self.mountpoint + "/BDMV"):
+        elif dir_in_mount("BDMV"):
             logging.debug(f"Found: {self.mountpoint}/BDMV")
             self.disctype = "bluray"
-        elif os.path.isdir(self.mountpoint + "/HVDVD_TS"):
+        elif dir_in_mount("HVDVD_TS"):
             logging.debug(f"Found: {self.mountpoint}/HVDVD_TS")
             # do something here
         elif found_hvdvd_ts:


### PR DESCRIPTION
# Description
Fixes #1746 - Burned UDF DVD-Rs misidentified as data discs due to stale file handle in get_disc_type

get_disc_type() used os.path.isdir() to detect VIDEO_TS on the mounted disc. On burned DVD-Rs with a UDF filesystem, the directory entry for VIDEO_TS is visible in the mountpoint listing but os.stat() fails with a stale file handle, causing os.path.isdir() to return False. ARM then falls through to disctype = "data" and performs a raw ISO dump instead of invoking MakeMKV.

Two module-level helpers are introduced: _disc_dir_exists() checks for a directory by listing the mountpoint root (case-insensitive), avoiding the stale handle issue entirely; _listdir_safe() wraps os.listdir() with OSError handling. Note: ARM_CHECK_UDF: false does not fix this — the stale file handle occurs after mounting regardless of that setting.

Fixes #1746 

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested in Docker on ARM 2.23.2 with multiple burned UDF DVD-Rs (church/educational distributed discs with LABEL="DVDROM"). Prior to fix, all were ISO-dumped as data discs. After fix, all correctly identified as disctype: dvd and ripped/transcoded successfully via MakeMKV + FFmpeg.

You can reproduce the stale file handle independently:


mount /dev/sr0 /mnt/disc
find /mnt/disc -maxdepth 2
# VIDEO_TS appears but: "find: '/mnt/disc/VIDEO_TS': Stale file handle"
docker exec -it arm makemkvcon info disc:0
# MakeMKV reads disc fine via direct access


- [x] Docker

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Added _disc_dir_exists() helper to detect disc directories via mountpoint listing, handling stale file handle errors on burned UDF discs
- Added _listdir_safe() helper wrapping os.listdir() with OSError handling
- Refactored get_disc_type() to use new helpers, removing redundant case-variant directory checks


# Logs
04-05-2026 21:37:56 ARM: INFO: Successfully mounted disc to /mnt/dev/sr0
04-05-2026 21:37:56 ARM: INFO: Disc identified as video
04-05-2026 21:37:57 ARM: INFO: Disc title Post ident - title:DVDROM year:None video_type:unknown disctype: dvd
04-05-2026 21:37:57 ARM: INFO: Waiting 120 seconds for manual override.
04-05-2026 21:38:12 ARM: INFO: Manual override found. Overriding auto identification values.
04-05-2026 21:38:12 ARM: INFO: title: Movie Title
04-05-2026 21:38:12 ARM: INFO: year: Year
04-05-2026 21:38:12 ARM: INFO: video_type: movie
04-05-2026 21:38:12 ARM: INFO: disctype: dvd
04-05-2026 21:38:12 ARM: INFO: ************* Ripping disc with MakeMKV *************
04-05-2026 21:39:18 ARM: INFO: Found 1 titles
04-05-2026 21:39:18 ARM: INFO: Process all tracks from disc.
04-05-2026 21:49:27 ARM: INFO: ************* Ripping with MakeMKV completed *************
04-05-2026 21:49:27 ARM: INFO: ************* Starting Transcode With FFMPEG *************
04-05-2026 21:51:42 ARM: INFO: FFmpeg call successful
04-05-2026 21:51:42 ARM: INFO: ************* Finished Transcode With FFMPEG *************
04-05-2026 21:51:42 ARM: INFO: Track is the Main Title. Moving to /home/arm/media/completed/movies/Movie Title (Year)/Movie Title (Year).mkv
04-05-2026 21:51:45 ARM: INFO: ************* ARM processing complete *************

