### PR TITLE
[BUGFIX] ARM UI progress bar not updating during rip - reads wrong log file

### DIFF
--- a/arm/ui/json_api.py
+++ b/arm/ui/json_api.py
@@ -112,8 +112,7 @@ def process_makemkv_logfile(job, job_results):
     """
     job_progress_status = None
     job_stage_index = None
-    lines = read_log_line(os.path.join(cfg.arm_config['LOGPATH'], job.logfile))
-    # Correctly get last entry for progress bar
+    lines = read_log_line(os.path.join(cfg.arm_config['LOGPATH'], 'progress', f'{job.job_id}.log'))    # Correctly get last entry for progress bar
     for line in lines:
         job_progress_status = re.search(r"PRGV:(\d{3,}),(\d+),(\d{3,})", str(line))
         job_stage_index = re.search(r"PRGC:\d+,(\d+),\"([\w -]{2,})\"", str(line))


### PR DESCRIPTION
# Description
Fixed a bug where the ARM web UI progress bar remained at 0% during active ripping jobs. The issue was in `/opt/arm/arm/ui/json_api.py` line 115, where the `process_makemkv_logfile()` function was reading the main job log file instead of the MakeMKV progress log file.

**Root Cause:**
The code was reading `job.logfile` (e.g., `MOVIR.log`) which only contains job metadata and configuration. MakeMKV writes real-time progress data with `PRGV:` entries to a separate file in the `progress/` subdirectory (e.g., `progress/987.log`).

**Fix:**
Changed the log path in `process_makemkv_logfile()` to read from the correct progress log file using the job ID.

Fixes #(issue for progress bar not updating)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
Please also list any relevant details for your test configuration

- [x] Docker
- [ ] Other (Please state here)

**Test Configuration:**
- ARM version: v2.23.2 (commit 7c034584, built April 27, 2026)
- MakeMKV version: v1.18

# Checklist:

- [X] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have tested that my fix is effective or that my feature works

