### PR TITLE
[BUGFIX] Fix string concatenation error when NTFY_PORT set

### DIFF
--- a/arm/ripper/apprise_bulk.py
+++ b/arm/ripper/apprise_bulk.py
@@ -127,7 +127,7 @@ def ntfy_notify(cfg, title, body):
                 ntfy_serverstring += host
 
             if host != "" and cfg['NTFY_PORT'] != "":
-                ntfy_serverstring += ':' + cfg['NTFY_PORT'] + '/'
+                ntfy_serverstring += ':' + str(cfg['NTFY_PORT']) + '/'
             else:
                 if ntfy_serverstring != 'ntfy://':
                     ntfy_serverstring += '/'


### PR DESCRIPTION
# Description
When NTFY_PORT is set through the web interface, it is stored as an integer in apprise.yaml.
NTFY notifications would fail when NTFY_PORT was set as apprise_bulk.py was trying to concatenate the integer with the server string:

`ERROR: apprise_bulk.ntfy_notify: Failed sending ntfy apprise notification. Continuing  processing...can only concatenate str (not "int") to str`

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Tested change on main branch with NTFY_TOPIC, NTFY_URL, and NTFY_PORT set.
Tested again with NTFY_PORT unset.

- [x] Docker
- [ ] Other (Please state here)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:

Include the details of changes made here
- Cast NTFY_PORT to string before appending to server URL

# Logs
arm-rippers-1  | DEBUG: utils.notify: apprise message, title: [NAS] - ARM notification body: This is a notification by the ARM-Notification Test! Server URL: http://xxx
arm-rippers-1  | DEBUG: utils.database_adder: Trying to add Notifications
arm-rippers-1  | DEBUG: utils.database_adder: successfully written Notifications to the database
arm-rippers-1  | DEBUG: apprise_bulk.ntfy_notify: Sent apprise to ntfy was successful
