### PR TITLE
[BUGFIX] Fix AttributeError when job_batch_info is None during ripping status

### DIFF
--- a/arm/ui/json_api.py
+++ b/arm/ui/json_api.py
@@ -144,17 +144,21 @@ def process_makemkv_logfile(job, job_results):
             f"{percentage(job_progress_status.group(1), job_progress_status.group(3)):.2f}"
         job.progress_round = percentage(job_progress_status.group(1),
                                         job_progress_status.group(3))
-        job_start_time = int(job_batch_info.group(1))
-        current_time = int(time())
-        elapsed_time = current_time - job_start_time
-        total_time = int((elapsed_time * 100) / float(job.progress))
-        time_remaining = total_time - elapsed_time
-        app.logger.debug(f"ETA values for job {job.job_id}: Elapsed seconds: {elapsed_time}, "
-                         f"Percent: {job.progress}, "
-                         f"Projected time: {total_time}, "
-                         f"Time remaining: {time_remaining}"
-                         )
-        job.eta = strftime("%Hh%Mm%Ss", gmtime(time_remaining))
+        if job_batch_info is not None:
+            job_start_time = int(job_batch_info.group(1))
+            current_time = int(time())
+            elapsed_time = current_time - job_start_time
+            total_time = int((elapsed_time * 100) / float(job.progress))
+            time_remaining = total_time - elapsed_time
+            app.logger.debug(f"ETA values for job {job.job_id}: Elapsed seconds: {elapsed_time}, "
+                             f"Percent: {job.progress}, "
+                             f"Projected time: {total_time}, "
+                             f"Time remaining: {time_remaining}"
+                             )
+            job.eta = strftime("%Hh%Mm%Ss", gmtime(time_remaining))
+        else:
+            app.logger.debug(f"Job [{job.job_id}] batch info not yet available - setting eta to Unknown")
+            job.eta = "Unknown"
     else:
         app.logger.debug(f"Job [{job.job_id}] MakeMKV status not defined - setting progress to 0%")
         job.progress = job.progress_round = job_results['progress'] = 0


### PR DESCRIPTION
# Title
[BUGFIX] Fix AttributeError when job_batch_info is None during ripping status

# Description
Job cards disappeared from the homepage/AJAX job list whenever a job's
status transitioned to `ripping` shortly after MakeMKV started. This was
caused by `process_makemkv_logfile()` in `arm/ui/json_api.py` calling
`job_batch_info.group(1)` without first checking that `job_batch_info`
was not `None`.

This happens when the main progress log (`PRGV`) already has an entry
but the `.log.batchinfo` file hasn't been written yet. The resulting
`AttributeError: 'NoneType' object has no attribute 'group'` caused the
entire `/json` endpoint request to fail, which the frontend
(`jobRefresh.js`, `checkActiveJobs()`) interpreted as "no active jobs",
removing ALL currently displayed jobs from the UI - not just the
affected one.

## Root cause
This bug was introduced by #1736, which added batch-info-based ETA
calculation to `process_makemkv_logfile()`. The new code calls
`job_batch_info.group(1)` without checking that `job_batch_info` is not
`None`, which happens whenever the `.log.batchinfo` file hasn't been
written yet at the moment the main progress log already has an entry.

Related to #1736 (introduced the regression)

Fixes # (no existing issue filed - found and fixed directly)

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?
Reproduced on a fresh native install (Ubuntu 26.04, Python 3.14, ARM
2.24.0). Ripped a Blu-ray with `RIPMETHOD: mkv` and watched the homepage
while the job transitioned to `ripping`. Before the fix, all job cards
(including an unrelated in-progress transcode job) disappeared from the
homepage for a period after the disc started being read, and the
browser console/network tab showed the `/json` endpoint returning the
error `'NoneType' object has no attribute 'group'`. After applying the
fix, the job list remained stable through the same transition across
multiple rips, and the error no longer appears.

- [ ] Docker
- [x] Other (native install, Ubuntu 26.04, Python 3.14.4)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have tested that my fix is effective or that my feature works

# Changelog:
- Added a `None` check for `job_batch_info` in `process_makemkv_logfile()`
  before calling `.group()` on it
- Falls back to `job.eta = "Unknown"` (matching the existing pattern used
  for `job_progress_status`) when batch info isn't available yet
- Added a debug log message for this fallback case

# Logs
Response from `/json?mode=joblist` before the fix (captured via Firefox
DevTools → Network tab):
Error    "'NoneType' object has no attribute 'group'"
path    "/json"
After applying the fix, this error no longer occurs and the job list
stays populated through the status transition.